### PR TITLE
Updated packages and modified configurations accordingly

### DIFF
--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -7,8 +7,10 @@ global.___loader = {
   enqueue: () => {},
   hovering: () => {},
 }
-// This is to utilise and override the window.___push method Gatsby defines and uses to report what path a Link would be taking us to if it wasn't inside a storybook
-window.___push = pathname => {
+// Gatsby internal mocking to prevent unnecessary errors in storybook testing environment
+global.__PATH_PREFIX__ = ''
+// This is to utilise and override the window.___navigate method Gatsby defines and uses to report what path a Link would be taking us to if it wasn't inside a storybook
+window.___navigate = pathname => {
   action('NavigateTo:')(pathname)
 }
 

--- a/__mocks__/gatsby.js
+++ b/__mocks__/gatsby.js
@@ -1,13 +1,2 @@
 'use strict'
-import React from 'react'
-const gatsby = jest.genMockFromModule('gatsby')
-gatsby.Link = ({ to, activeClassName, activeStyle, isActive, ...props }) => (
-  <a
-    href={to}
-    activeclassname={activeClassName}
-    activestyle={activeStyle}
-    isactive={isActive}
-    {...props}
-  />
-)
-module.exports = gatsby
+module.exports = jest.genMockFromModule('gatsby')

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,26 +5,27 @@
   "requires": true,
   "dependencies": {
     "@babel/code-frame": {
-      "version": "7.0.0-beta.52",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.52.tgz",
-      "integrity": "sha1-GSSDv6DR5GfBAVccIQKcy3SvKAE=",
+      "version": "7.0.0-rc.2",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-rc.2.tgz",
+      "integrity": "sha512-+cVix+HBNakVp7IU1WReJV8dnJl/yaBA5JRXc758BSrvJCH2hKp1Z0xHIiUaOvxMwKXc3EXGIYhlnx5T+6ofGA==",
+      "dev": true,
       "requires": {
-        "@babel/highlight": "7.0.0-beta.52"
+        "@babel/highlight": "7.0.0-rc.2"
       }
     },
     "@babel/core": {
-      "version": "7.0.0-beta.56",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.0.0-beta.56.tgz",
-      "integrity": "sha512-IsytpdHZqo5pgJj4FTcpEMKmfXK9TdvThLZo4yUOjbuVZCy8NAwoeBnojvKCNf+139L7xNIIosp3RVA0cMkbOg==",
+      "version": "7.0.0-rc.2",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.0.0-rc.2.tgz",
+      "integrity": "sha512-8VZqKdLMUBfvSDq+V8CWjVBh7y+b2FY+4daFAWN0pgrdgw/UfrEy8afe9CVfppwblROZZVCxGWSSGOBo84rQjg==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "7.0.0-beta.56",
-        "@babel/generator": "7.0.0-beta.56",
-        "@babel/helpers": "7.0.0-beta.56",
-        "@babel/parser": "7.0.0-beta.56",
-        "@babel/template": "7.0.0-beta.56",
-        "@babel/traverse": "7.0.0-beta.56",
-        "@babel/types": "7.0.0-beta.56",
+        "@babel/code-frame": "7.0.0-rc.2",
+        "@babel/generator": "7.0.0-rc.2",
+        "@babel/helpers": "7.0.0-rc.2",
+        "@babel/parser": "7.0.0-rc.2",
+        "@babel/template": "7.0.0-rc.2",
+        "@babel/traverse": "7.0.0-rc.2",
+        "@babel/types": "7.0.0-rc.2",
         "convert-source-map": "^1.1.0",
         "debug": "^3.1.0",
         "json5": "^0.5.0",
@@ -32,1482 +33,341 @@
         "resolve": "^1.3.2",
         "semver": "^5.4.1",
         "source-map": "^0.5.0"
-      },
-      "dependencies": {
-        "@babel/code-frame": {
-          "version": "7.0.0-beta.56",
-          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.56.tgz",
-          "integrity": "sha512-OBeGs8UXWpKl0oK2T5nUXNl2yu8RKxqL/7aUnMtKDXCU6VUrNP3npdrPivBA11HPB15TVI49nWf2lntTzoUuAg==",
-          "dev": true,
-          "requires": {
-            "@babel/highlight": "7.0.0-beta.56"
-          }
-        },
-        "@babel/generator": {
-          "version": "7.0.0-beta.56",
-          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.0.0-beta.56.tgz",
-          "integrity": "sha512-d+Ls/Vr5OU5FBDYQToXSqAluI3r2UaSoNZ41zD3sxdoVoaT8K5Bdh4So4eG4o//INGM7actValXGfb+5J1+r8w==",
-          "dev": true,
-          "requires": {
-            "@babel/types": "7.0.0-beta.56",
-            "jsesc": "^2.5.1",
-            "lodash": "^4.17.10",
-            "source-map": "^0.5.0",
-            "trim-right": "^1.0.1"
-          }
-        },
-        "@babel/helper-function-name": {
-          "version": "7.0.0-beta.56",
-          "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.0.0-beta.56.tgz",
-          "integrity": "sha512-Lq4nPOt1j3sUq+1GVrw57dKq6wBKAHplGjYzEG8dkytqo93i6uSKKKg3smYXx2qohEVD5ciAyJjgRJq7RQu4Lg==",
-          "dev": true,
-          "requires": {
-            "@babel/helper-get-function-arity": "7.0.0-beta.56",
-            "@babel/template": "7.0.0-beta.56",
-            "@babel/types": "7.0.0-beta.56"
-          }
-        },
-        "@babel/helper-get-function-arity": {
-          "version": "7.0.0-beta.56",
-          "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.56.tgz",
-          "integrity": "sha512-QU9EVlnDGTzBasgrdo/I4+RzZS7oqzz9YcetpYko3bp+VsRGokqsAQl3gIvxWTtxwibwboDEdBx+fGArtb2fhw==",
-          "dev": true,
-          "requires": {
-            "@babel/types": "7.0.0-beta.56"
-          }
-        },
-        "@babel/helper-split-export-declaration": {
-          "version": "7.0.0-beta.56",
-          "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0-beta.56.tgz",
-          "integrity": "sha512-j886mQJQg5HDF7X0qK/AfNdrpIYUcJHxRKwBJ9dUvhpO3eFqsTLbJJpitgLaJQjh9D7Db5Aiq8MRghj3+MH57g==",
-          "dev": true,
-          "requires": {
-            "@babel/types": "7.0.0-beta.56"
-          }
-        },
-        "@babel/highlight": {
-          "version": "7.0.0-beta.56",
-          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-beta.56.tgz",
-          "integrity": "sha512-q4TfI+jJISul6vVpZJktzH4tupwRiVk6KXRhB8PHqJ7erl966I6ePDXl9mAbE8jMM7YswhnnB0j1SYP7LBVyhg==",
-          "dev": true,
-          "requires": {
-            "chalk": "^2.0.0",
-            "esutils": "^2.0.2",
-            "js-tokens": "^3.0.0"
-          }
-        },
-        "@babel/parser": {
-          "version": "7.0.0-beta.56",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.0.0-beta.56.tgz",
-          "integrity": "sha512-JM0ughhbo+sPXw2Z+SUyowfYrAOhjanzjMshcLswBdXVelJCOeEKe/FqMqPWGVPQr7wByongXIn+MKdCpY7DBw==",
-          "dev": true
-        },
-        "@babel/template": {
-          "version": "7.0.0-beta.56",
-          "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.0.0-beta.56.tgz",
-          "integrity": "sha512-rsR9K18h0oiJTUmS/ICYREbV8qhPTic4SIqDSkzv9xOxupt7dKj8hWmZQLGPySO5x6cdn8py039o1wPQnsEGHg==",
-          "dev": true,
-          "requires": {
-            "@babel/code-frame": "7.0.0-beta.56",
-            "@babel/parser": "7.0.0-beta.56",
-            "@babel/types": "7.0.0-beta.56",
-            "lodash": "^4.17.10"
-          }
-        },
-        "@babel/traverse": {
-          "version": "7.0.0-beta.56",
-          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.0.0-beta.56.tgz",
-          "integrity": "sha512-9WTqtKP2Ll+jG68r+JEecXAbdH/kk5inN1VDSDaTgdYtZ82BYUS9XRWMVpc5HB9LJsu2ZEyUA1cGybID7eeOXA==",
-          "dev": true,
-          "requires": {
-            "@babel/code-frame": "7.0.0-beta.56",
-            "@babel/generator": "7.0.0-beta.56",
-            "@babel/helper-function-name": "7.0.0-beta.56",
-            "@babel/helper-split-export-declaration": "7.0.0-beta.56",
-            "@babel/parser": "7.0.0-beta.56",
-            "@babel/types": "7.0.0-beta.56",
-            "debug": "^3.1.0",
-            "globals": "^11.1.0",
-            "lodash": "^4.17.10"
-          }
-        },
-        "@babel/types": {
-          "version": "7.0.0-beta.56",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.56.tgz",
-          "integrity": "sha512-fRIBeHtKxAD3D1E7hYSpG4MnLt0AfzHHs5gfVclOB0NlfLu3qiWU/IqdbK2ixTK61424iEkV1P/VAzndx6ungA==",
-          "dev": true,
-          "requires": {
-            "esutils": "^2.0.2",
-            "lodash": "^4.17.10",
-            "to-fast-properties": "^2.0.0"
-          }
-        }
       }
     },
     "@babel/generator": {
-      "version": "7.0.0-beta.52",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.0.0-beta.52.tgz",
-      "integrity": "sha1-JpaPEvrYGM2XTISbKGtDfh6MzZE=",
+      "version": "7.0.0-rc.2",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.0.0-rc.2.tgz",
+      "integrity": "sha512-kD6hlprDaBy17V8qd9uXJbYC5ZYyCggieT+tiGzCwayA7oyT5ynPec3MNkWQHkLyhB7IP2n3c/Ep329jOPQY/g==",
+      "dev": true,
       "requires": {
-        "@babel/types": "7.0.0-beta.52",
+        "@babel/types": "7.0.0-rc.2",
         "jsesc": "^2.5.1",
-        "lodash": "^4.17.5",
+        "lodash": "^4.17.10",
         "source-map": "^0.5.0",
         "trim-right": "^1.0.1"
       }
     },
     "@babel/helper-annotate-as-pure": {
-      "version": "7.0.0-beta.56",
-      "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.0.0-beta.56.tgz",
-      "integrity": "sha512-PaHQ8R489lwBZYz/F81YpKDurIQfKWliNIpHZAysYbnozq8hVyaUx8D5wW6Dplf0lUUQ8Y/I3YKtiNoyg7bLHA==",
+      "version": "7.0.0-rc.2",
+      "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.0.0-rc.2.tgz",
+      "integrity": "sha512-HukwqtJnDKo4++QL33d1cKwULDENi2YziqG4goiRiILJsVZYdZxEaOho0RYlzsKEvq4A70sbakUMw3bFC3kp3g==",
       "dev": true,
       "requires": {
-        "@babel/types": "7.0.0-beta.56"
-      },
-      "dependencies": {
-        "@babel/types": {
-          "version": "7.0.0-beta.56",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.56.tgz",
-          "integrity": "sha512-fRIBeHtKxAD3D1E7hYSpG4MnLt0AfzHHs5gfVclOB0NlfLu3qiWU/IqdbK2ixTK61424iEkV1P/VAzndx6ungA==",
-          "dev": true,
-          "requires": {
-            "esutils": "^2.0.2",
-            "lodash": "^4.17.10",
-            "to-fast-properties": "^2.0.0"
-          }
-        }
+        "@babel/types": "7.0.0-rc.2"
       }
     },
     "@babel/helper-builder-binary-assignment-operator-visitor": {
-      "version": "7.0.0-beta.56",
-      "resolved": "https://registry.npmjs.org/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.0.0-beta.56.tgz",
-      "integrity": "sha512-ka5Fe6UB/jRtCWU/emg6fLKqttaVaBCF1zdT06PYs7w8hJPidCcfdVMBoDHfqL3pgLo+hp+LW4Q/99zw/zv0Sw==",
+      "version": "7.0.0-rc.2",
+      "resolved": "https://registry.npmjs.org/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.0.0-rc.2.tgz",
+      "integrity": "sha512-xiq0+9lNdVKX8fKIjrcdOgBEHH9JMR9cVYwdPmp1lXORS3zV/QpZAxQVOeOI4oXbdUPx6jfy3tKyrfhLQBXuuA==",
       "dev": true,
       "requires": {
-        "@babel/helper-explode-assignable-expression": "7.0.0-beta.56",
-        "@babel/types": "7.0.0-beta.56"
-      },
-      "dependencies": {
-        "@babel/types": {
-          "version": "7.0.0-beta.56",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.56.tgz",
-          "integrity": "sha512-fRIBeHtKxAD3D1E7hYSpG4MnLt0AfzHHs5gfVclOB0NlfLu3qiWU/IqdbK2ixTK61424iEkV1P/VAzndx6ungA==",
-          "dev": true,
-          "requires": {
-            "esutils": "^2.0.2",
-            "lodash": "^4.17.10",
-            "to-fast-properties": "^2.0.0"
-          }
-        }
+        "@babel/helper-explode-assignable-expression": "7.0.0-rc.2",
+        "@babel/types": "7.0.0-rc.2"
       }
     },
     "@babel/helper-builder-react-jsx": {
-      "version": "7.0.0-beta.56",
-      "resolved": "https://registry.npmjs.org/@babel/helper-builder-react-jsx/-/helper-builder-react-jsx-7.0.0-beta.56.tgz",
-      "integrity": "sha512-s7nY9YbY+/6yccMCdI9oqh/rZ9lEoo3EHk/Lt6H2p/t6jyQf0sWqtsbJeHg5j5FzX6ZwYkdX8lTmBBMTrlyf9A==",
+      "version": "7.0.0-rc.2",
+      "resolved": "https://registry.npmjs.org/@babel/helper-builder-react-jsx/-/helper-builder-react-jsx-7.0.0-rc.2.tgz",
+      "integrity": "sha512-uQGEgtdTB0XVgYpr/OJ52C/4CIPjED7XO8g8R64Am/RSVY0Ah0/H7ae6TbvW+v9eFbVZSvdm8ODb7sdEfMTCAg==",
       "dev": true,
       "requires": {
-        "@babel/types": "7.0.0-beta.56",
+        "@babel/types": "7.0.0-rc.2",
         "esutils": "^2.0.0"
-      },
-      "dependencies": {
-        "@babel/types": {
-          "version": "7.0.0-beta.56",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.56.tgz",
-          "integrity": "sha512-fRIBeHtKxAD3D1E7hYSpG4MnLt0AfzHHs5gfVclOB0NlfLu3qiWU/IqdbK2ixTK61424iEkV1P/VAzndx6ungA==",
-          "dev": true,
-          "requires": {
-            "esutils": "^2.0.2",
-            "lodash": "^4.17.10",
-            "to-fast-properties": "^2.0.0"
-          }
-        }
       }
     },
     "@babel/helper-call-delegate": {
-      "version": "7.0.0-beta.56",
-      "resolved": "https://registry.npmjs.org/@babel/helper-call-delegate/-/helper-call-delegate-7.0.0-beta.56.tgz",
-      "integrity": "sha512-XOv0taD7Elw0CSorktXbbCzdPgH4dZOb8yObk5deEhDbWgJhdwIvd5z8rQpDu712oqDhXm7Z3v+upFsOCg2+nQ==",
+      "version": "7.0.0-rc.2",
+      "resolved": "https://registry.npmjs.org/@babel/helper-call-delegate/-/helper-call-delegate-7.0.0-rc.2.tgz",
+      "integrity": "sha512-RbPyt1vkOzeCV0Gowma4aLSs3odq3/MLpxC/Qaki7Wjbq4yyNGsUAgO1J7ZB/YYbB11PX5OesA1OVKw03RLOrg==",
       "dev": true,
       "requires": {
-        "@babel/helper-hoist-variables": "7.0.0-beta.56",
-        "@babel/traverse": "7.0.0-beta.56",
-        "@babel/types": "7.0.0-beta.56"
-      },
-      "dependencies": {
-        "@babel/code-frame": {
-          "version": "7.0.0-beta.56",
-          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.56.tgz",
-          "integrity": "sha512-OBeGs8UXWpKl0oK2T5nUXNl2yu8RKxqL/7aUnMtKDXCU6VUrNP3npdrPivBA11HPB15TVI49nWf2lntTzoUuAg==",
-          "dev": true,
-          "requires": {
-            "@babel/highlight": "7.0.0-beta.56"
-          }
-        },
-        "@babel/generator": {
-          "version": "7.0.0-beta.56",
-          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.0.0-beta.56.tgz",
-          "integrity": "sha512-d+Ls/Vr5OU5FBDYQToXSqAluI3r2UaSoNZ41zD3sxdoVoaT8K5Bdh4So4eG4o//INGM7actValXGfb+5J1+r8w==",
-          "dev": true,
-          "requires": {
-            "@babel/types": "7.0.0-beta.56",
-            "jsesc": "^2.5.1",
-            "lodash": "^4.17.10",
-            "source-map": "^0.5.0",
-            "trim-right": "^1.0.1"
-          }
-        },
-        "@babel/helper-function-name": {
-          "version": "7.0.0-beta.56",
-          "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.0.0-beta.56.tgz",
-          "integrity": "sha512-Lq4nPOt1j3sUq+1GVrw57dKq6wBKAHplGjYzEG8dkytqo93i6uSKKKg3smYXx2qohEVD5ciAyJjgRJq7RQu4Lg==",
-          "dev": true,
-          "requires": {
-            "@babel/helper-get-function-arity": "7.0.0-beta.56",
-            "@babel/template": "7.0.0-beta.56",
-            "@babel/types": "7.0.0-beta.56"
-          }
-        },
-        "@babel/helper-get-function-arity": {
-          "version": "7.0.0-beta.56",
-          "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.56.tgz",
-          "integrity": "sha512-QU9EVlnDGTzBasgrdo/I4+RzZS7oqzz9YcetpYko3bp+VsRGokqsAQl3gIvxWTtxwibwboDEdBx+fGArtb2fhw==",
-          "dev": true,
-          "requires": {
-            "@babel/types": "7.0.0-beta.56"
-          }
-        },
-        "@babel/helper-split-export-declaration": {
-          "version": "7.0.0-beta.56",
-          "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0-beta.56.tgz",
-          "integrity": "sha512-j886mQJQg5HDF7X0qK/AfNdrpIYUcJHxRKwBJ9dUvhpO3eFqsTLbJJpitgLaJQjh9D7Db5Aiq8MRghj3+MH57g==",
-          "dev": true,
-          "requires": {
-            "@babel/types": "7.0.0-beta.56"
-          }
-        },
-        "@babel/highlight": {
-          "version": "7.0.0-beta.56",
-          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-beta.56.tgz",
-          "integrity": "sha512-q4TfI+jJISul6vVpZJktzH4tupwRiVk6KXRhB8PHqJ7erl966I6ePDXl9mAbE8jMM7YswhnnB0j1SYP7LBVyhg==",
-          "dev": true,
-          "requires": {
-            "chalk": "^2.0.0",
-            "esutils": "^2.0.2",
-            "js-tokens": "^3.0.0"
-          }
-        },
-        "@babel/parser": {
-          "version": "7.0.0-beta.56",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.0.0-beta.56.tgz",
-          "integrity": "sha512-JM0ughhbo+sPXw2Z+SUyowfYrAOhjanzjMshcLswBdXVelJCOeEKe/FqMqPWGVPQr7wByongXIn+MKdCpY7DBw==",
-          "dev": true
-        },
-        "@babel/template": {
-          "version": "7.0.0-beta.56",
-          "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.0.0-beta.56.tgz",
-          "integrity": "sha512-rsR9K18h0oiJTUmS/ICYREbV8qhPTic4SIqDSkzv9xOxupt7dKj8hWmZQLGPySO5x6cdn8py039o1wPQnsEGHg==",
-          "dev": true,
-          "requires": {
-            "@babel/code-frame": "7.0.0-beta.56",
-            "@babel/parser": "7.0.0-beta.56",
-            "@babel/types": "7.0.0-beta.56",
-            "lodash": "^4.17.10"
-          }
-        },
-        "@babel/traverse": {
-          "version": "7.0.0-beta.56",
-          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.0.0-beta.56.tgz",
-          "integrity": "sha512-9WTqtKP2Ll+jG68r+JEecXAbdH/kk5inN1VDSDaTgdYtZ82BYUS9XRWMVpc5HB9LJsu2ZEyUA1cGybID7eeOXA==",
-          "dev": true,
-          "requires": {
-            "@babel/code-frame": "7.0.0-beta.56",
-            "@babel/generator": "7.0.0-beta.56",
-            "@babel/helper-function-name": "7.0.0-beta.56",
-            "@babel/helper-split-export-declaration": "7.0.0-beta.56",
-            "@babel/parser": "7.0.0-beta.56",
-            "@babel/types": "7.0.0-beta.56",
-            "debug": "^3.1.0",
-            "globals": "^11.1.0",
-            "lodash": "^4.17.10"
-          }
-        },
-        "@babel/types": {
-          "version": "7.0.0-beta.56",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.56.tgz",
-          "integrity": "sha512-fRIBeHtKxAD3D1E7hYSpG4MnLt0AfzHHs5gfVclOB0NlfLu3qiWU/IqdbK2ixTK61424iEkV1P/VAzndx6ungA==",
-          "dev": true,
-          "requires": {
-            "esutils": "^2.0.2",
-            "lodash": "^4.17.10",
-            "to-fast-properties": "^2.0.0"
-          }
-        }
+        "@babel/helper-hoist-variables": "7.0.0-rc.2",
+        "@babel/traverse": "7.0.0-rc.2",
+        "@babel/types": "7.0.0-rc.2"
       }
     },
     "@babel/helper-define-map": {
-      "version": "7.0.0-beta.56",
-      "resolved": "https://registry.npmjs.org/@babel/helper-define-map/-/helper-define-map-7.0.0-beta.56.tgz",
-      "integrity": "sha512-6hWVBpEyeRqvX3cKU7GVjdiYk9SvucpScTwdNpuSvsX8lX1MzuLQ7n9FNrHMU6+ulVNkZV81E7WdABYgXyIfuw==",
+      "version": "7.0.0-rc.2",
+      "resolved": "https://registry.npmjs.org/@babel/helper-define-map/-/helper-define-map-7.0.0-rc.2.tgz",
+      "integrity": "sha512-fquxtu2DZ1QUpoNoCmw/Bqi5IAyLGCvEanP1/rpOZp+MULe6qnULeGVnR5aftIsi9nTC2XPWEqjb8fANmI6x7w==",
       "dev": true,
       "requires": {
-        "@babel/helper-function-name": "7.0.0-beta.56",
-        "@babel/types": "7.0.0-beta.56",
+        "@babel/helper-function-name": "7.0.0-rc.2",
+        "@babel/types": "7.0.0-rc.2",
         "lodash": "^4.17.10"
-      },
-      "dependencies": {
-        "@babel/code-frame": {
-          "version": "7.0.0-beta.56",
-          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.56.tgz",
-          "integrity": "sha512-OBeGs8UXWpKl0oK2T5nUXNl2yu8RKxqL/7aUnMtKDXCU6VUrNP3npdrPivBA11HPB15TVI49nWf2lntTzoUuAg==",
-          "dev": true,
-          "requires": {
-            "@babel/highlight": "7.0.0-beta.56"
-          }
-        },
-        "@babel/helper-function-name": {
-          "version": "7.0.0-beta.56",
-          "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.0.0-beta.56.tgz",
-          "integrity": "sha512-Lq4nPOt1j3sUq+1GVrw57dKq6wBKAHplGjYzEG8dkytqo93i6uSKKKg3smYXx2qohEVD5ciAyJjgRJq7RQu4Lg==",
-          "dev": true,
-          "requires": {
-            "@babel/helper-get-function-arity": "7.0.0-beta.56",
-            "@babel/template": "7.0.0-beta.56",
-            "@babel/types": "7.0.0-beta.56"
-          }
-        },
-        "@babel/helper-get-function-arity": {
-          "version": "7.0.0-beta.56",
-          "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.56.tgz",
-          "integrity": "sha512-QU9EVlnDGTzBasgrdo/I4+RzZS7oqzz9YcetpYko3bp+VsRGokqsAQl3gIvxWTtxwibwboDEdBx+fGArtb2fhw==",
-          "dev": true,
-          "requires": {
-            "@babel/types": "7.0.0-beta.56"
-          }
-        },
-        "@babel/highlight": {
-          "version": "7.0.0-beta.56",
-          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-beta.56.tgz",
-          "integrity": "sha512-q4TfI+jJISul6vVpZJktzH4tupwRiVk6KXRhB8PHqJ7erl966I6ePDXl9mAbE8jMM7YswhnnB0j1SYP7LBVyhg==",
-          "dev": true,
-          "requires": {
-            "chalk": "^2.0.0",
-            "esutils": "^2.0.2",
-            "js-tokens": "^3.0.0"
-          }
-        },
-        "@babel/parser": {
-          "version": "7.0.0-beta.56",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.0.0-beta.56.tgz",
-          "integrity": "sha512-JM0ughhbo+sPXw2Z+SUyowfYrAOhjanzjMshcLswBdXVelJCOeEKe/FqMqPWGVPQr7wByongXIn+MKdCpY7DBw==",
-          "dev": true
-        },
-        "@babel/template": {
-          "version": "7.0.0-beta.56",
-          "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.0.0-beta.56.tgz",
-          "integrity": "sha512-rsR9K18h0oiJTUmS/ICYREbV8qhPTic4SIqDSkzv9xOxupt7dKj8hWmZQLGPySO5x6cdn8py039o1wPQnsEGHg==",
-          "dev": true,
-          "requires": {
-            "@babel/code-frame": "7.0.0-beta.56",
-            "@babel/parser": "7.0.0-beta.56",
-            "@babel/types": "7.0.0-beta.56",
-            "lodash": "^4.17.10"
-          }
-        },
-        "@babel/types": {
-          "version": "7.0.0-beta.56",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.56.tgz",
-          "integrity": "sha512-fRIBeHtKxAD3D1E7hYSpG4MnLt0AfzHHs5gfVclOB0NlfLu3qiWU/IqdbK2ixTK61424iEkV1P/VAzndx6ungA==",
-          "dev": true,
-          "requires": {
-            "esutils": "^2.0.2",
-            "lodash": "^4.17.10",
-            "to-fast-properties": "^2.0.0"
-          }
-        }
       }
     },
     "@babel/helper-explode-assignable-expression": {
-      "version": "7.0.0-beta.56",
-      "resolved": "https://registry.npmjs.org/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.0.0-beta.56.tgz",
-      "integrity": "sha512-Y3a7HLnwLJEiKe4+XB2AEo6QiCnFsa0ycqg6HBp0lyw4HztSTGt3oyZYO8I5ZhtVCKi/EJXSQuKHLOV98jG/+A==",
+      "version": "7.0.0-rc.2",
+      "resolved": "https://registry.npmjs.org/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.0.0-rc.2.tgz",
+      "integrity": "sha512-fEmCM0mYCJNuT4hf7EZ3g1K8/CDeo/Ynl1YkKU8HAa6zBo9Kt+4zicFBLgEYDBLogNLPbjBl+0YqR0Fkr5+WJg==",
       "dev": true,
       "requires": {
-        "@babel/traverse": "7.0.0-beta.56",
-        "@babel/types": "7.0.0-beta.56"
-      },
-      "dependencies": {
-        "@babel/code-frame": {
-          "version": "7.0.0-beta.56",
-          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.56.tgz",
-          "integrity": "sha512-OBeGs8UXWpKl0oK2T5nUXNl2yu8RKxqL/7aUnMtKDXCU6VUrNP3npdrPivBA11HPB15TVI49nWf2lntTzoUuAg==",
-          "dev": true,
-          "requires": {
-            "@babel/highlight": "7.0.0-beta.56"
-          }
-        },
-        "@babel/generator": {
-          "version": "7.0.0-beta.56",
-          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.0.0-beta.56.tgz",
-          "integrity": "sha512-d+Ls/Vr5OU5FBDYQToXSqAluI3r2UaSoNZ41zD3sxdoVoaT8K5Bdh4So4eG4o//INGM7actValXGfb+5J1+r8w==",
-          "dev": true,
-          "requires": {
-            "@babel/types": "7.0.0-beta.56",
-            "jsesc": "^2.5.1",
-            "lodash": "^4.17.10",
-            "source-map": "^0.5.0",
-            "trim-right": "^1.0.1"
-          }
-        },
-        "@babel/helper-function-name": {
-          "version": "7.0.0-beta.56",
-          "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.0.0-beta.56.tgz",
-          "integrity": "sha512-Lq4nPOt1j3sUq+1GVrw57dKq6wBKAHplGjYzEG8dkytqo93i6uSKKKg3smYXx2qohEVD5ciAyJjgRJq7RQu4Lg==",
-          "dev": true,
-          "requires": {
-            "@babel/helper-get-function-arity": "7.0.0-beta.56",
-            "@babel/template": "7.0.0-beta.56",
-            "@babel/types": "7.0.0-beta.56"
-          }
-        },
-        "@babel/helper-get-function-arity": {
-          "version": "7.0.0-beta.56",
-          "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.56.tgz",
-          "integrity": "sha512-QU9EVlnDGTzBasgrdo/I4+RzZS7oqzz9YcetpYko3bp+VsRGokqsAQl3gIvxWTtxwibwboDEdBx+fGArtb2fhw==",
-          "dev": true,
-          "requires": {
-            "@babel/types": "7.0.0-beta.56"
-          }
-        },
-        "@babel/helper-split-export-declaration": {
-          "version": "7.0.0-beta.56",
-          "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0-beta.56.tgz",
-          "integrity": "sha512-j886mQJQg5HDF7X0qK/AfNdrpIYUcJHxRKwBJ9dUvhpO3eFqsTLbJJpitgLaJQjh9D7Db5Aiq8MRghj3+MH57g==",
-          "dev": true,
-          "requires": {
-            "@babel/types": "7.0.0-beta.56"
-          }
-        },
-        "@babel/highlight": {
-          "version": "7.0.0-beta.56",
-          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-beta.56.tgz",
-          "integrity": "sha512-q4TfI+jJISul6vVpZJktzH4tupwRiVk6KXRhB8PHqJ7erl966I6ePDXl9mAbE8jMM7YswhnnB0j1SYP7LBVyhg==",
-          "dev": true,
-          "requires": {
-            "chalk": "^2.0.0",
-            "esutils": "^2.0.2",
-            "js-tokens": "^3.0.0"
-          }
-        },
-        "@babel/parser": {
-          "version": "7.0.0-beta.56",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.0.0-beta.56.tgz",
-          "integrity": "sha512-JM0ughhbo+sPXw2Z+SUyowfYrAOhjanzjMshcLswBdXVelJCOeEKe/FqMqPWGVPQr7wByongXIn+MKdCpY7DBw==",
-          "dev": true
-        },
-        "@babel/template": {
-          "version": "7.0.0-beta.56",
-          "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.0.0-beta.56.tgz",
-          "integrity": "sha512-rsR9K18h0oiJTUmS/ICYREbV8qhPTic4SIqDSkzv9xOxupt7dKj8hWmZQLGPySO5x6cdn8py039o1wPQnsEGHg==",
-          "dev": true,
-          "requires": {
-            "@babel/code-frame": "7.0.0-beta.56",
-            "@babel/parser": "7.0.0-beta.56",
-            "@babel/types": "7.0.0-beta.56",
-            "lodash": "^4.17.10"
-          }
-        },
-        "@babel/traverse": {
-          "version": "7.0.0-beta.56",
-          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.0.0-beta.56.tgz",
-          "integrity": "sha512-9WTqtKP2Ll+jG68r+JEecXAbdH/kk5inN1VDSDaTgdYtZ82BYUS9XRWMVpc5HB9LJsu2ZEyUA1cGybID7eeOXA==",
-          "dev": true,
-          "requires": {
-            "@babel/code-frame": "7.0.0-beta.56",
-            "@babel/generator": "7.0.0-beta.56",
-            "@babel/helper-function-name": "7.0.0-beta.56",
-            "@babel/helper-split-export-declaration": "7.0.0-beta.56",
-            "@babel/parser": "7.0.0-beta.56",
-            "@babel/types": "7.0.0-beta.56",
-            "debug": "^3.1.0",
-            "globals": "^11.1.0",
-            "lodash": "^4.17.10"
-          }
-        },
-        "@babel/types": {
-          "version": "7.0.0-beta.56",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.56.tgz",
-          "integrity": "sha512-fRIBeHtKxAD3D1E7hYSpG4MnLt0AfzHHs5gfVclOB0NlfLu3qiWU/IqdbK2ixTK61424iEkV1P/VAzndx6ungA==",
-          "dev": true,
-          "requires": {
-            "esutils": "^2.0.2",
-            "lodash": "^4.17.10",
-            "to-fast-properties": "^2.0.0"
-          }
-        }
+        "@babel/traverse": "7.0.0-rc.2",
+        "@babel/types": "7.0.0-rc.2"
       }
     },
     "@babel/helper-function-name": {
-      "version": "7.0.0-beta.52",
-      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.0.0-beta.52.tgz",
-      "integrity": "sha1-qGelj/VxsldysteZsyhmBYVzxFA=",
+      "version": "7.0.0-rc.2",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.0.0-rc.2.tgz",
+      "integrity": "sha512-1frd4Bm/8yfZoAj87tmB6gtQNWtKAzfRzjASVdmsItzq9X13yUlyFLdo6/tNhazftwJO8iIZeadOpi3rNKDXhg==",
+      "dev": true,
       "requires": {
-        "@babel/helper-get-function-arity": "7.0.0-beta.52",
-        "@babel/template": "7.0.0-beta.52",
-        "@babel/types": "7.0.0-beta.52"
+        "@babel/helper-get-function-arity": "7.0.0-rc.2",
+        "@babel/template": "7.0.0-rc.2",
+        "@babel/types": "7.0.0-rc.2"
       }
     },
     "@babel/helper-get-function-arity": {
-      "version": "7.0.0-beta.52",
-      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.52.tgz",
-      "integrity": "sha1-HAzaWOC3X0XpLq+9j+GJpO7pK3Q=",
+      "version": "7.0.0-rc.2",
+      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-rc.2.tgz",
+      "integrity": "sha512-5tjNc0hYngGqBGdjvzN89p92WY6aCntaDv8AadB/xgyUx4VievZwEbz8pc6GKkO6+qfghfZhv1F3+9SC6IA3Eg==",
+      "dev": true,
       "requires": {
-        "@babel/types": "7.0.0-beta.52"
+        "@babel/types": "7.0.0-rc.2"
       }
     },
     "@babel/helper-hoist-variables": {
-      "version": "7.0.0-beta.56",
-      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.0.0-beta.56.tgz",
-      "integrity": "sha512-PTBa6UfiM7MgeTXOlNjCDiiqtOhqWraHM2GGsZg1M8VkuZRjP1Kag9JNmoppUlsZE5LY3NE+BjJuQ1/mLgcIug==",
+      "version": "7.0.0-rc.2",
+      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.0.0-rc.2.tgz",
+      "integrity": "sha512-nxLyQK592UW/IOQA04cnheKVr57bIKVeMRjkZp3yWwRtzlVCNABW2AdlP9WPlF+Db7ATcw4vcrpnrelSi7ivBw==",
       "dev": true,
       "requires": {
-        "@babel/types": "7.0.0-beta.56"
-      },
-      "dependencies": {
-        "@babel/types": {
-          "version": "7.0.0-beta.56",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.56.tgz",
-          "integrity": "sha512-fRIBeHtKxAD3D1E7hYSpG4MnLt0AfzHHs5gfVclOB0NlfLu3qiWU/IqdbK2ixTK61424iEkV1P/VAzndx6ungA==",
-          "dev": true,
-          "requires": {
-            "esutils": "^2.0.2",
-            "lodash": "^4.17.10",
-            "to-fast-properties": "^2.0.0"
-          }
-        }
+        "@babel/types": "7.0.0-rc.2"
       }
     },
     "@babel/helper-member-expression-to-functions": {
-      "version": "7.0.0-beta.56",
-      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.0.0-beta.56.tgz",
-      "integrity": "sha512-/TrmPCG1XIENakzenEyiNsbIBSTm10DNWyB/cyKwVljzA18gMivn9YxSMxVAuaC1KyTTmhkeUYibSMF7yF13xw==",
+      "version": "7.0.0-rc.2",
+      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.0.0-rc.2.tgz",
+      "integrity": "sha512-8OFFup4az2I+icJL+VPjAIrZZsc7YlS6p8OgC53Nb1JFQ/mvKK8wuHxnNIt63tTIMkBPLRYaZScdij6GpDzCGA==",
       "dev": true,
       "requires": {
-        "@babel/types": "7.0.0-beta.56"
-      },
-      "dependencies": {
-        "@babel/types": {
-          "version": "7.0.0-beta.56",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.56.tgz",
-          "integrity": "sha512-fRIBeHtKxAD3D1E7hYSpG4MnLt0AfzHHs5gfVclOB0NlfLu3qiWU/IqdbK2ixTK61424iEkV1P/VAzndx6ungA==",
-          "dev": true,
-          "requires": {
-            "esutils": "^2.0.2",
-            "lodash": "^4.17.10",
-            "to-fast-properties": "^2.0.0"
-          }
-        }
+        "@babel/types": "7.0.0-rc.2"
       }
     },
     "@babel/helper-module-imports": {
-      "version": "7.0.0-beta.52",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.0.0-beta.52.tgz",
-      "integrity": "sha1-cIQOg66JH5RwLGxhN4fEjuPJZbs=",
+      "version": "7.0.0-rc.2",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.0.0-rc.2.tgz",
+      "integrity": "sha512-4HmUjJ7dwnhhTNOoxOxHe9e24nnzd9VjXNXLcKdw98aRxiFQhBxhOk2t8kX2XMcGVJrFHob5zfVEjgMvnkCmHw==",
+      "dev": true,
       "requires": {
-        "@babel/types": "7.0.0-beta.52",
-        "lodash": "^4.17.5"
+        "@babel/types": "7.0.0-rc.2"
       }
     },
     "@babel/helper-module-transforms": {
-      "version": "7.0.0-beta.56",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.0.0-beta.56.tgz",
-      "integrity": "sha512-jC+blwjVeVx43WWOJHHXYBcHvYw0eHNgZUUXHKkDTLYc0zx8oev3LyciGFiWz29KgCS1K8YYd0t7z8fFXlCTog==",
+      "version": "7.0.0-rc.2",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.0.0-rc.2.tgz",
+      "integrity": "sha512-tMGTJiSPa3naZNYfhIBF6ma5TfhyWq8PZe5i9ZemreDx4ffToad0MqQ6OW7g0U9S6a3RlZO1639Wc3DQNyvJlw==",
       "dev": true,
       "requires": {
-        "@babel/helper-module-imports": "7.0.0-beta.56",
-        "@babel/helper-simple-access": "7.0.0-beta.56",
-        "@babel/helper-split-export-declaration": "7.0.0-beta.56",
-        "@babel/template": "7.0.0-beta.56",
-        "@babel/types": "7.0.0-beta.56",
+        "@babel/helper-module-imports": "7.0.0-rc.2",
+        "@babel/helper-simple-access": "7.0.0-rc.2",
+        "@babel/helper-split-export-declaration": "7.0.0-rc.2",
+        "@babel/template": "7.0.0-rc.2",
+        "@babel/types": "7.0.0-rc.2",
         "lodash": "^4.17.10"
-      },
-      "dependencies": {
-        "@babel/code-frame": {
-          "version": "7.0.0-beta.56",
-          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.56.tgz",
-          "integrity": "sha512-OBeGs8UXWpKl0oK2T5nUXNl2yu8RKxqL/7aUnMtKDXCU6VUrNP3npdrPivBA11HPB15TVI49nWf2lntTzoUuAg==",
-          "dev": true,
-          "requires": {
-            "@babel/highlight": "7.0.0-beta.56"
-          }
-        },
-        "@babel/helper-module-imports": {
-          "version": "7.0.0-beta.56",
-          "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.0.0-beta.56.tgz",
-          "integrity": "sha512-iVWFscU+yIu6DIo5IWkMgVXd74/d3z/ZomwF/QJNGFwFP/lNA282rpjsky56fSxS7oT7wAlXoYoHVCOOaL7tbg==",
-          "dev": true,
-          "requires": {
-            "@babel/types": "7.0.0-beta.56",
-            "lodash": "^4.17.10"
-          }
-        },
-        "@babel/helper-split-export-declaration": {
-          "version": "7.0.0-beta.56",
-          "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0-beta.56.tgz",
-          "integrity": "sha512-j886mQJQg5HDF7X0qK/AfNdrpIYUcJHxRKwBJ9dUvhpO3eFqsTLbJJpitgLaJQjh9D7Db5Aiq8MRghj3+MH57g==",
-          "dev": true,
-          "requires": {
-            "@babel/types": "7.0.0-beta.56"
-          }
-        },
-        "@babel/highlight": {
-          "version": "7.0.0-beta.56",
-          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-beta.56.tgz",
-          "integrity": "sha512-q4TfI+jJISul6vVpZJktzH4tupwRiVk6KXRhB8PHqJ7erl966I6ePDXl9mAbE8jMM7YswhnnB0j1SYP7LBVyhg==",
-          "dev": true,
-          "requires": {
-            "chalk": "^2.0.0",
-            "esutils": "^2.0.2",
-            "js-tokens": "^3.0.0"
-          }
-        },
-        "@babel/parser": {
-          "version": "7.0.0-beta.56",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.0.0-beta.56.tgz",
-          "integrity": "sha512-JM0ughhbo+sPXw2Z+SUyowfYrAOhjanzjMshcLswBdXVelJCOeEKe/FqMqPWGVPQr7wByongXIn+MKdCpY7DBw==",
-          "dev": true
-        },
-        "@babel/template": {
-          "version": "7.0.0-beta.56",
-          "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.0.0-beta.56.tgz",
-          "integrity": "sha512-rsR9K18h0oiJTUmS/ICYREbV8qhPTic4SIqDSkzv9xOxupt7dKj8hWmZQLGPySO5x6cdn8py039o1wPQnsEGHg==",
-          "dev": true,
-          "requires": {
-            "@babel/code-frame": "7.0.0-beta.56",
-            "@babel/parser": "7.0.0-beta.56",
-            "@babel/types": "7.0.0-beta.56",
-            "lodash": "^4.17.10"
-          }
-        },
-        "@babel/types": {
-          "version": "7.0.0-beta.56",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.56.tgz",
-          "integrity": "sha512-fRIBeHtKxAD3D1E7hYSpG4MnLt0AfzHHs5gfVclOB0NlfLu3qiWU/IqdbK2ixTK61424iEkV1P/VAzndx6ungA==",
-          "dev": true,
-          "requires": {
-            "esutils": "^2.0.2",
-            "lodash": "^4.17.10",
-            "to-fast-properties": "^2.0.0"
-          }
-        }
       }
     },
     "@babel/helper-optimise-call-expression": {
-      "version": "7.0.0-beta.56",
-      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.0.0-beta.56.tgz",
-      "integrity": "sha512-T+eZePA6kM+3wHXDPKKFZGHtMJGfK2/xmdk9pVjFHppdg4zwEqGaqLQaOlqfk5ekx2vxO22tmL4Caf2A/MVm0w==",
+      "version": "7.0.0-rc.2",
+      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.0.0-rc.2.tgz",
+      "integrity": "sha512-O/rWpfst/rKucph1U0Hy8YDwoHBNwAZJqv7rDOp00S7eMYbU8wDYgG43J+mJcYV+2WV2dqoym6j9QdV4xTvEsw==",
       "dev": true,
       "requires": {
-        "@babel/types": "7.0.0-beta.56"
-      },
-      "dependencies": {
-        "@babel/types": {
-          "version": "7.0.0-beta.56",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.56.tgz",
-          "integrity": "sha512-fRIBeHtKxAD3D1E7hYSpG4MnLt0AfzHHs5gfVclOB0NlfLu3qiWU/IqdbK2ixTK61424iEkV1P/VAzndx6ungA==",
-          "dev": true,
-          "requires": {
-            "esutils": "^2.0.2",
-            "lodash": "^4.17.10",
-            "to-fast-properties": "^2.0.0"
-          }
-        }
+        "@babel/types": "7.0.0-rc.2"
       }
     },
     "@babel/helper-plugin-utils": {
-      "version": "7.0.0-beta.52",
-      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0-beta.52.tgz",
-      "integrity": "sha1-LwWMX3w6X+S8IZA2sueOEb3et60="
+      "version": "7.0.0-rc.2",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0-rc.2.tgz",
+      "integrity": "sha512-kavwJYTgdd5W12MpfMJMznrfsx3sCl0HMSJ0vsPcbwT9jhF0EmYL1eyfeYbo4pToYmQgPKp+VGtSHQ3wL8N5lQ==",
+      "dev": true
     },
     "@babel/helper-regex": {
-      "version": "7.0.0-beta.56",
-      "resolved": "https://registry.npmjs.org/@babel/helper-regex/-/helper-regex-7.0.0-beta.56.tgz",
-      "integrity": "sha512-wtb8bmlc5TF7W7KMd5muS+CVQQu7cNGTdPbI5+8x5w36bN8ytbkun5160hJ2S1r3Tti0FPnrYwz+9W5AGj+d9g==",
+      "version": "7.0.0-rc.2",
+      "resolved": "https://registry.npmjs.org/@babel/helper-regex/-/helper-regex-7.0.0-rc.2.tgz",
+      "integrity": "sha512-QXqgALeUqvEq0+PjWHyOWz4ZTnSs0rXXgNpwhbkud4nXfl7w7CMtCRPOadRDRjJ2kMpQ47jM0unn7mrUnNmYnA==",
       "dev": true,
       "requires": {
         "lodash": "^4.17.10"
       }
     },
     "@babel/helper-remap-async-to-generator": {
-      "version": "7.0.0-beta.56",
-      "resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.0.0-beta.56.tgz",
-      "integrity": "sha512-uCvdjXeEh/qzvhK61XLP5DADCM0MMxZOVdGIj5In/i9MLt9BD/EAyBmjZN0bc1dD1wJst0qInZyZju0lUUkvNQ==",
+      "version": "7.0.0-rc.2",
+      "resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.0.0-rc.2.tgz",
+      "integrity": "sha512-JqxhwM6dK1vCEeGeKqSssjD/yEOo5EophV94lcnutP355UApapzzNnw1hJ08irqYo0nYOqpiMP5uIdBhwxmu5A==",
       "dev": true,
       "requires": {
-        "@babel/helper-annotate-as-pure": "7.0.0-beta.56",
-        "@babel/helper-wrap-function": "7.0.0-beta.56",
-        "@babel/template": "7.0.0-beta.56",
-        "@babel/traverse": "7.0.0-beta.56",
-        "@babel/types": "7.0.0-beta.56"
-      },
-      "dependencies": {
-        "@babel/code-frame": {
-          "version": "7.0.0-beta.56",
-          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.56.tgz",
-          "integrity": "sha512-OBeGs8UXWpKl0oK2T5nUXNl2yu8RKxqL/7aUnMtKDXCU6VUrNP3npdrPivBA11HPB15TVI49nWf2lntTzoUuAg==",
-          "dev": true,
-          "requires": {
-            "@babel/highlight": "7.0.0-beta.56"
-          }
-        },
-        "@babel/generator": {
-          "version": "7.0.0-beta.56",
-          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.0.0-beta.56.tgz",
-          "integrity": "sha512-d+Ls/Vr5OU5FBDYQToXSqAluI3r2UaSoNZ41zD3sxdoVoaT8K5Bdh4So4eG4o//INGM7actValXGfb+5J1+r8w==",
-          "dev": true,
-          "requires": {
-            "@babel/types": "7.0.0-beta.56",
-            "jsesc": "^2.5.1",
-            "lodash": "^4.17.10",
-            "source-map": "^0.5.0",
-            "trim-right": "^1.0.1"
-          }
-        },
-        "@babel/helper-function-name": {
-          "version": "7.0.0-beta.56",
-          "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.0.0-beta.56.tgz",
-          "integrity": "sha512-Lq4nPOt1j3sUq+1GVrw57dKq6wBKAHplGjYzEG8dkytqo93i6uSKKKg3smYXx2qohEVD5ciAyJjgRJq7RQu4Lg==",
-          "dev": true,
-          "requires": {
-            "@babel/helper-get-function-arity": "7.0.0-beta.56",
-            "@babel/template": "7.0.0-beta.56",
-            "@babel/types": "7.0.0-beta.56"
-          }
-        },
-        "@babel/helper-get-function-arity": {
-          "version": "7.0.0-beta.56",
-          "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.56.tgz",
-          "integrity": "sha512-QU9EVlnDGTzBasgrdo/I4+RzZS7oqzz9YcetpYko3bp+VsRGokqsAQl3gIvxWTtxwibwboDEdBx+fGArtb2fhw==",
-          "dev": true,
-          "requires": {
-            "@babel/types": "7.0.0-beta.56"
-          }
-        },
-        "@babel/helper-split-export-declaration": {
-          "version": "7.0.0-beta.56",
-          "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0-beta.56.tgz",
-          "integrity": "sha512-j886mQJQg5HDF7X0qK/AfNdrpIYUcJHxRKwBJ9dUvhpO3eFqsTLbJJpitgLaJQjh9D7Db5Aiq8MRghj3+MH57g==",
-          "dev": true,
-          "requires": {
-            "@babel/types": "7.0.0-beta.56"
-          }
-        },
-        "@babel/highlight": {
-          "version": "7.0.0-beta.56",
-          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-beta.56.tgz",
-          "integrity": "sha512-q4TfI+jJISul6vVpZJktzH4tupwRiVk6KXRhB8PHqJ7erl966I6ePDXl9mAbE8jMM7YswhnnB0j1SYP7LBVyhg==",
-          "dev": true,
-          "requires": {
-            "chalk": "^2.0.0",
-            "esutils": "^2.0.2",
-            "js-tokens": "^3.0.0"
-          }
-        },
-        "@babel/parser": {
-          "version": "7.0.0-beta.56",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.0.0-beta.56.tgz",
-          "integrity": "sha512-JM0ughhbo+sPXw2Z+SUyowfYrAOhjanzjMshcLswBdXVelJCOeEKe/FqMqPWGVPQr7wByongXIn+MKdCpY7DBw==",
-          "dev": true
-        },
-        "@babel/template": {
-          "version": "7.0.0-beta.56",
-          "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.0.0-beta.56.tgz",
-          "integrity": "sha512-rsR9K18h0oiJTUmS/ICYREbV8qhPTic4SIqDSkzv9xOxupt7dKj8hWmZQLGPySO5x6cdn8py039o1wPQnsEGHg==",
-          "dev": true,
-          "requires": {
-            "@babel/code-frame": "7.0.0-beta.56",
-            "@babel/parser": "7.0.0-beta.56",
-            "@babel/types": "7.0.0-beta.56",
-            "lodash": "^4.17.10"
-          }
-        },
-        "@babel/traverse": {
-          "version": "7.0.0-beta.56",
-          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.0.0-beta.56.tgz",
-          "integrity": "sha512-9WTqtKP2Ll+jG68r+JEecXAbdH/kk5inN1VDSDaTgdYtZ82BYUS9XRWMVpc5HB9LJsu2ZEyUA1cGybID7eeOXA==",
-          "dev": true,
-          "requires": {
-            "@babel/code-frame": "7.0.0-beta.56",
-            "@babel/generator": "7.0.0-beta.56",
-            "@babel/helper-function-name": "7.0.0-beta.56",
-            "@babel/helper-split-export-declaration": "7.0.0-beta.56",
-            "@babel/parser": "7.0.0-beta.56",
-            "@babel/types": "7.0.0-beta.56",
-            "debug": "^3.1.0",
-            "globals": "^11.1.0",
-            "lodash": "^4.17.10"
-          }
-        },
-        "@babel/types": {
-          "version": "7.0.0-beta.56",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.56.tgz",
-          "integrity": "sha512-fRIBeHtKxAD3D1E7hYSpG4MnLt0AfzHHs5gfVclOB0NlfLu3qiWU/IqdbK2ixTK61424iEkV1P/VAzndx6ungA==",
-          "dev": true,
-          "requires": {
-            "esutils": "^2.0.2",
-            "lodash": "^4.17.10",
-            "to-fast-properties": "^2.0.0"
-          }
-        }
+        "@babel/helper-annotate-as-pure": "7.0.0-rc.2",
+        "@babel/helper-wrap-function": "7.0.0-rc.2",
+        "@babel/template": "7.0.0-rc.2",
+        "@babel/traverse": "7.0.0-rc.2",
+        "@babel/types": "7.0.0-rc.2"
       }
     },
     "@babel/helper-replace-supers": {
-      "version": "7.0.0-beta.56",
-      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.0.0-beta.56.tgz",
-      "integrity": "sha512-Pv0a8XYWeYLMgzx6BiKYMkBPW7ilDeKmKnPfMD+sCsTRDMZl9DssqnkkSwGxgAeuPwZ9opx18r5EzYPTgt0k4A==",
+      "version": "7.0.0-rc.2",
+      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.0.0-rc.2.tgz",
+      "integrity": "sha512-MdMAYjNacQ3pCMNvAs31Nkp4UZTAE9ahMnJvkqIjgB7YgpNFfRI/8BX97SyWKe4qlNrkVxCE6WrY2s9nJBh7uA==",
       "dev": true,
       "requires": {
-        "@babel/helper-member-expression-to-functions": "7.0.0-beta.56",
-        "@babel/helper-optimise-call-expression": "7.0.0-beta.56",
-        "@babel/traverse": "7.0.0-beta.56",
-        "@babel/types": "7.0.0-beta.56"
-      },
-      "dependencies": {
-        "@babel/code-frame": {
-          "version": "7.0.0-beta.56",
-          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.56.tgz",
-          "integrity": "sha512-OBeGs8UXWpKl0oK2T5nUXNl2yu8RKxqL/7aUnMtKDXCU6VUrNP3npdrPivBA11HPB15TVI49nWf2lntTzoUuAg==",
-          "dev": true,
-          "requires": {
-            "@babel/highlight": "7.0.0-beta.56"
-          }
-        },
-        "@babel/generator": {
-          "version": "7.0.0-beta.56",
-          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.0.0-beta.56.tgz",
-          "integrity": "sha512-d+Ls/Vr5OU5FBDYQToXSqAluI3r2UaSoNZ41zD3sxdoVoaT8K5Bdh4So4eG4o//INGM7actValXGfb+5J1+r8w==",
-          "dev": true,
-          "requires": {
-            "@babel/types": "7.0.0-beta.56",
-            "jsesc": "^2.5.1",
-            "lodash": "^4.17.10",
-            "source-map": "^0.5.0",
-            "trim-right": "^1.0.1"
-          }
-        },
-        "@babel/helper-function-name": {
-          "version": "7.0.0-beta.56",
-          "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.0.0-beta.56.tgz",
-          "integrity": "sha512-Lq4nPOt1j3sUq+1GVrw57dKq6wBKAHplGjYzEG8dkytqo93i6uSKKKg3smYXx2qohEVD5ciAyJjgRJq7RQu4Lg==",
-          "dev": true,
-          "requires": {
-            "@babel/helper-get-function-arity": "7.0.0-beta.56",
-            "@babel/template": "7.0.0-beta.56",
-            "@babel/types": "7.0.0-beta.56"
-          }
-        },
-        "@babel/helper-get-function-arity": {
-          "version": "7.0.0-beta.56",
-          "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.56.tgz",
-          "integrity": "sha512-QU9EVlnDGTzBasgrdo/I4+RzZS7oqzz9YcetpYko3bp+VsRGokqsAQl3gIvxWTtxwibwboDEdBx+fGArtb2fhw==",
-          "dev": true,
-          "requires": {
-            "@babel/types": "7.0.0-beta.56"
-          }
-        },
-        "@babel/helper-split-export-declaration": {
-          "version": "7.0.0-beta.56",
-          "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0-beta.56.tgz",
-          "integrity": "sha512-j886mQJQg5HDF7X0qK/AfNdrpIYUcJHxRKwBJ9dUvhpO3eFqsTLbJJpitgLaJQjh9D7Db5Aiq8MRghj3+MH57g==",
-          "dev": true,
-          "requires": {
-            "@babel/types": "7.0.0-beta.56"
-          }
-        },
-        "@babel/highlight": {
-          "version": "7.0.0-beta.56",
-          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-beta.56.tgz",
-          "integrity": "sha512-q4TfI+jJISul6vVpZJktzH4tupwRiVk6KXRhB8PHqJ7erl966I6ePDXl9mAbE8jMM7YswhnnB0j1SYP7LBVyhg==",
-          "dev": true,
-          "requires": {
-            "chalk": "^2.0.0",
-            "esutils": "^2.0.2",
-            "js-tokens": "^3.0.0"
-          }
-        },
-        "@babel/parser": {
-          "version": "7.0.0-beta.56",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.0.0-beta.56.tgz",
-          "integrity": "sha512-JM0ughhbo+sPXw2Z+SUyowfYrAOhjanzjMshcLswBdXVelJCOeEKe/FqMqPWGVPQr7wByongXIn+MKdCpY7DBw==",
-          "dev": true
-        },
-        "@babel/template": {
-          "version": "7.0.0-beta.56",
-          "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.0.0-beta.56.tgz",
-          "integrity": "sha512-rsR9K18h0oiJTUmS/ICYREbV8qhPTic4SIqDSkzv9xOxupt7dKj8hWmZQLGPySO5x6cdn8py039o1wPQnsEGHg==",
-          "dev": true,
-          "requires": {
-            "@babel/code-frame": "7.0.0-beta.56",
-            "@babel/parser": "7.0.0-beta.56",
-            "@babel/types": "7.0.0-beta.56",
-            "lodash": "^4.17.10"
-          }
-        },
-        "@babel/traverse": {
-          "version": "7.0.0-beta.56",
-          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.0.0-beta.56.tgz",
-          "integrity": "sha512-9WTqtKP2Ll+jG68r+JEecXAbdH/kk5inN1VDSDaTgdYtZ82BYUS9XRWMVpc5HB9LJsu2ZEyUA1cGybID7eeOXA==",
-          "dev": true,
-          "requires": {
-            "@babel/code-frame": "7.0.0-beta.56",
-            "@babel/generator": "7.0.0-beta.56",
-            "@babel/helper-function-name": "7.0.0-beta.56",
-            "@babel/helper-split-export-declaration": "7.0.0-beta.56",
-            "@babel/parser": "7.0.0-beta.56",
-            "@babel/types": "7.0.0-beta.56",
-            "debug": "^3.1.0",
-            "globals": "^11.1.0",
-            "lodash": "^4.17.10"
-          }
-        },
-        "@babel/types": {
-          "version": "7.0.0-beta.56",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.56.tgz",
-          "integrity": "sha512-fRIBeHtKxAD3D1E7hYSpG4MnLt0AfzHHs5gfVclOB0NlfLu3qiWU/IqdbK2ixTK61424iEkV1P/VAzndx6ungA==",
-          "dev": true,
-          "requires": {
-            "esutils": "^2.0.2",
-            "lodash": "^4.17.10",
-            "to-fast-properties": "^2.0.0"
-          }
-        }
+        "@babel/helper-member-expression-to-functions": "7.0.0-rc.2",
+        "@babel/helper-optimise-call-expression": "7.0.0-rc.2",
+        "@babel/traverse": "7.0.0-rc.2",
+        "@babel/types": "7.0.0-rc.2"
       }
     },
     "@babel/helper-simple-access": {
-      "version": "7.0.0-beta.56",
-      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.0.0-beta.56.tgz",
-      "integrity": "sha512-CIRkGs+/KNWpGJKEUbABeVWTZ1ePskwKwwoR1lVs2qI4cZheS6NvXzLxsFN/uxyc46yn7px/XTxV/zM3rnlQQQ==",
+      "version": "7.0.0-rc.2",
+      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.0.0-rc.2.tgz",
+      "integrity": "sha512-Cw5mRtvW1jdmPWD+oLTUX8XkpyftA8AskpaQzuRkxg7dcjAnmXOUYBsccBZ8vTbrxrRzX5WrdRTwbmtx/Q9uNg==",
       "dev": true,
       "requires": {
-        "@babel/template": "7.0.0-beta.56",
-        "@babel/types": "7.0.0-beta.56",
-        "lodash": "^4.17.10"
-      },
-      "dependencies": {
-        "@babel/code-frame": {
-          "version": "7.0.0-beta.56",
-          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.56.tgz",
-          "integrity": "sha512-OBeGs8UXWpKl0oK2T5nUXNl2yu8RKxqL/7aUnMtKDXCU6VUrNP3npdrPivBA11HPB15TVI49nWf2lntTzoUuAg==",
-          "dev": true,
-          "requires": {
-            "@babel/highlight": "7.0.0-beta.56"
-          }
-        },
-        "@babel/highlight": {
-          "version": "7.0.0-beta.56",
-          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-beta.56.tgz",
-          "integrity": "sha512-q4TfI+jJISul6vVpZJktzH4tupwRiVk6KXRhB8PHqJ7erl966I6ePDXl9mAbE8jMM7YswhnnB0j1SYP7LBVyhg==",
-          "dev": true,
-          "requires": {
-            "chalk": "^2.0.0",
-            "esutils": "^2.0.2",
-            "js-tokens": "^3.0.0"
-          }
-        },
-        "@babel/parser": {
-          "version": "7.0.0-beta.56",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.0.0-beta.56.tgz",
-          "integrity": "sha512-JM0ughhbo+sPXw2Z+SUyowfYrAOhjanzjMshcLswBdXVelJCOeEKe/FqMqPWGVPQr7wByongXIn+MKdCpY7DBw==",
-          "dev": true
-        },
-        "@babel/template": {
-          "version": "7.0.0-beta.56",
-          "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.0.0-beta.56.tgz",
-          "integrity": "sha512-rsR9K18h0oiJTUmS/ICYREbV8qhPTic4SIqDSkzv9xOxupt7dKj8hWmZQLGPySO5x6cdn8py039o1wPQnsEGHg==",
-          "dev": true,
-          "requires": {
-            "@babel/code-frame": "7.0.0-beta.56",
-            "@babel/parser": "7.0.0-beta.56",
-            "@babel/types": "7.0.0-beta.56",
-            "lodash": "^4.17.10"
-          }
-        },
-        "@babel/types": {
-          "version": "7.0.0-beta.56",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.56.tgz",
-          "integrity": "sha512-fRIBeHtKxAD3D1E7hYSpG4MnLt0AfzHHs5gfVclOB0NlfLu3qiWU/IqdbK2ixTK61424iEkV1P/VAzndx6ungA==",
-          "dev": true,
-          "requires": {
-            "esutils": "^2.0.2",
-            "lodash": "^4.17.10",
-            "to-fast-properties": "^2.0.0"
-          }
-        }
+        "@babel/template": "7.0.0-rc.2",
+        "@babel/types": "7.0.0-rc.2"
       }
     },
     "@babel/helper-split-export-declaration": {
-      "version": "7.0.0-beta.52",
-      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0-beta.52.tgz",
-      "integrity": "sha1-SqxPMOpjhK82duBLUkZydjLkYN8=",
+      "version": "7.0.0-rc.2",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0-rc.2.tgz",
+      "integrity": "sha512-MBtzTAeZT7MxWETY0JRh5yyIKY4tN/q68BU4/XgzZUaHJ+G74fJUoR7mPO3TbTiwLIEFVBbZQA9AG4yYqe5W2g==",
+      "dev": true,
       "requires": {
-        "@babel/types": "7.0.0-beta.52"
+        "@babel/types": "7.0.0-rc.2"
       }
     },
     "@babel/helper-wrap-function": {
-      "version": "7.0.0-beta.56",
-      "resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.0.0-beta.56.tgz",
-      "integrity": "sha512-WuGMzbpx12M40aHtocM0vs9af/LmdwpXsKBX2T2GqCMueD90MHvQU+148vHScgPbUoWP4lv+dFGZDf0XUc2qJA==",
+      "version": "7.0.0-rc.2",
+      "resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.0.0-rc.2.tgz",
+      "integrity": "sha512-uq+7oYjrJCDj2cV9ZpxiWzLeLZFmsM8V4lyfGyOIEsv87biGE+UcOb8R0OHnA8Hkq2CpF73pCj7nm3tdhj8k+g==",
       "dev": true,
       "requires": {
-        "@babel/helper-function-name": "7.0.0-beta.56",
-        "@babel/template": "7.0.0-beta.56",
-        "@babel/traverse": "7.0.0-beta.56",
-        "@babel/types": "7.0.0-beta.56"
-      },
-      "dependencies": {
-        "@babel/code-frame": {
-          "version": "7.0.0-beta.56",
-          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.56.tgz",
-          "integrity": "sha512-OBeGs8UXWpKl0oK2T5nUXNl2yu8RKxqL/7aUnMtKDXCU6VUrNP3npdrPivBA11HPB15TVI49nWf2lntTzoUuAg==",
-          "dev": true,
-          "requires": {
-            "@babel/highlight": "7.0.0-beta.56"
-          }
-        },
-        "@babel/generator": {
-          "version": "7.0.0-beta.56",
-          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.0.0-beta.56.tgz",
-          "integrity": "sha512-d+Ls/Vr5OU5FBDYQToXSqAluI3r2UaSoNZ41zD3sxdoVoaT8K5Bdh4So4eG4o//INGM7actValXGfb+5J1+r8w==",
-          "dev": true,
-          "requires": {
-            "@babel/types": "7.0.0-beta.56",
-            "jsesc": "^2.5.1",
-            "lodash": "^4.17.10",
-            "source-map": "^0.5.0",
-            "trim-right": "^1.0.1"
-          }
-        },
-        "@babel/helper-function-name": {
-          "version": "7.0.0-beta.56",
-          "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.0.0-beta.56.tgz",
-          "integrity": "sha512-Lq4nPOt1j3sUq+1GVrw57dKq6wBKAHplGjYzEG8dkytqo93i6uSKKKg3smYXx2qohEVD5ciAyJjgRJq7RQu4Lg==",
-          "dev": true,
-          "requires": {
-            "@babel/helper-get-function-arity": "7.0.0-beta.56",
-            "@babel/template": "7.0.0-beta.56",
-            "@babel/types": "7.0.0-beta.56"
-          }
-        },
-        "@babel/helper-get-function-arity": {
-          "version": "7.0.0-beta.56",
-          "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.56.tgz",
-          "integrity": "sha512-QU9EVlnDGTzBasgrdo/I4+RzZS7oqzz9YcetpYko3bp+VsRGokqsAQl3gIvxWTtxwibwboDEdBx+fGArtb2fhw==",
-          "dev": true,
-          "requires": {
-            "@babel/types": "7.0.0-beta.56"
-          }
-        },
-        "@babel/helper-split-export-declaration": {
-          "version": "7.0.0-beta.56",
-          "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0-beta.56.tgz",
-          "integrity": "sha512-j886mQJQg5HDF7X0qK/AfNdrpIYUcJHxRKwBJ9dUvhpO3eFqsTLbJJpitgLaJQjh9D7Db5Aiq8MRghj3+MH57g==",
-          "dev": true,
-          "requires": {
-            "@babel/types": "7.0.0-beta.56"
-          }
-        },
-        "@babel/highlight": {
-          "version": "7.0.0-beta.56",
-          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-beta.56.tgz",
-          "integrity": "sha512-q4TfI+jJISul6vVpZJktzH4tupwRiVk6KXRhB8PHqJ7erl966I6ePDXl9mAbE8jMM7YswhnnB0j1SYP7LBVyhg==",
-          "dev": true,
-          "requires": {
-            "chalk": "^2.0.0",
-            "esutils": "^2.0.2",
-            "js-tokens": "^3.0.0"
-          }
-        },
-        "@babel/parser": {
-          "version": "7.0.0-beta.56",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.0.0-beta.56.tgz",
-          "integrity": "sha512-JM0ughhbo+sPXw2Z+SUyowfYrAOhjanzjMshcLswBdXVelJCOeEKe/FqMqPWGVPQr7wByongXIn+MKdCpY7DBw==",
-          "dev": true
-        },
-        "@babel/template": {
-          "version": "7.0.0-beta.56",
-          "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.0.0-beta.56.tgz",
-          "integrity": "sha512-rsR9K18h0oiJTUmS/ICYREbV8qhPTic4SIqDSkzv9xOxupt7dKj8hWmZQLGPySO5x6cdn8py039o1wPQnsEGHg==",
-          "dev": true,
-          "requires": {
-            "@babel/code-frame": "7.0.0-beta.56",
-            "@babel/parser": "7.0.0-beta.56",
-            "@babel/types": "7.0.0-beta.56",
-            "lodash": "^4.17.10"
-          }
-        },
-        "@babel/traverse": {
-          "version": "7.0.0-beta.56",
-          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.0.0-beta.56.tgz",
-          "integrity": "sha512-9WTqtKP2Ll+jG68r+JEecXAbdH/kk5inN1VDSDaTgdYtZ82BYUS9XRWMVpc5HB9LJsu2ZEyUA1cGybID7eeOXA==",
-          "dev": true,
-          "requires": {
-            "@babel/code-frame": "7.0.0-beta.56",
-            "@babel/generator": "7.0.0-beta.56",
-            "@babel/helper-function-name": "7.0.0-beta.56",
-            "@babel/helper-split-export-declaration": "7.0.0-beta.56",
-            "@babel/parser": "7.0.0-beta.56",
-            "@babel/types": "7.0.0-beta.56",
-            "debug": "^3.1.0",
-            "globals": "^11.1.0",
-            "lodash": "^4.17.10"
-          }
-        },
-        "@babel/types": {
-          "version": "7.0.0-beta.56",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.56.tgz",
-          "integrity": "sha512-fRIBeHtKxAD3D1E7hYSpG4MnLt0AfzHHs5gfVclOB0NlfLu3qiWU/IqdbK2ixTK61424iEkV1P/VAzndx6ungA==",
-          "dev": true,
-          "requires": {
-            "esutils": "^2.0.2",
-            "lodash": "^4.17.10",
-            "to-fast-properties": "^2.0.0"
-          }
-        }
+        "@babel/helper-function-name": "7.0.0-rc.2",
+        "@babel/template": "7.0.0-rc.2",
+        "@babel/traverse": "7.0.0-rc.2",
+        "@babel/types": "7.0.0-rc.2"
       }
     },
     "@babel/helpers": {
-      "version": "7.0.0-beta.56",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.0.0-beta.56.tgz",
-      "integrity": "sha512-KaNBuVlAGW6sFCEWjliN29dL8K4L/ff8ZUaR/D5ou/JsqOuxLRy34Rf8WXMru3Et2g4Czly6vJeSmaYyf3s0lA==",
+      "version": "7.0.0-rc.2",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.0.0-rc.2.tgz",
+      "integrity": "sha512-X5e6FnKEhS8UtSJfjjkEvY8Mq+W52FES6p55g16gHmVycVrggjwZryQKqK+iMJlus7Dgz6MrrdOtC1SWx4jDDg==",
       "dev": true,
       "requires": {
-        "@babel/template": "7.0.0-beta.56",
-        "@babel/traverse": "7.0.0-beta.56",
-        "@babel/types": "7.0.0-beta.56"
-      },
-      "dependencies": {
-        "@babel/code-frame": {
-          "version": "7.0.0-beta.56",
-          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.56.tgz",
-          "integrity": "sha512-OBeGs8UXWpKl0oK2T5nUXNl2yu8RKxqL/7aUnMtKDXCU6VUrNP3npdrPivBA11HPB15TVI49nWf2lntTzoUuAg==",
-          "dev": true,
-          "requires": {
-            "@babel/highlight": "7.0.0-beta.56"
-          }
-        },
-        "@babel/generator": {
-          "version": "7.0.0-beta.56",
-          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.0.0-beta.56.tgz",
-          "integrity": "sha512-d+Ls/Vr5OU5FBDYQToXSqAluI3r2UaSoNZ41zD3sxdoVoaT8K5Bdh4So4eG4o//INGM7actValXGfb+5J1+r8w==",
-          "dev": true,
-          "requires": {
-            "@babel/types": "7.0.0-beta.56",
-            "jsesc": "^2.5.1",
-            "lodash": "^4.17.10",
-            "source-map": "^0.5.0",
-            "trim-right": "^1.0.1"
-          }
-        },
-        "@babel/helper-function-name": {
-          "version": "7.0.0-beta.56",
-          "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.0.0-beta.56.tgz",
-          "integrity": "sha512-Lq4nPOt1j3sUq+1GVrw57dKq6wBKAHplGjYzEG8dkytqo93i6uSKKKg3smYXx2qohEVD5ciAyJjgRJq7RQu4Lg==",
-          "dev": true,
-          "requires": {
-            "@babel/helper-get-function-arity": "7.0.0-beta.56",
-            "@babel/template": "7.0.0-beta.56",
-            "@babel/types": "7.0.0-beta.56"
-          }
-        },
-        "@babel/helper-get-function-arity": {
-          "version": "7.0.0-beta.56",
-          "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.56.tgz",
-          "integrity": "sha512-QU9EVlnDGTzBasgrdo/I4+RzZS7oqzz9YcetpYko3bp+VsRGokqsAQl3gIvxWTtxwibwboDEdBx+fGArtb2fhw==",
-          "dev": true,
-          "requires": {
-            "@babel/types": "7.0.0-beta.56"
-          }
-        },
-        "@babel/helper-split-export-declaration": {
-          "version": "7.0.0-beta.56",
-          "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0-beta.56.tgz",
-          "integrity": "sha512-j886mQJQg5HDF7X0qK/AfNdrpIYUcJHxRKwBJ9dUvhpO3eFqsTLbJJpitgLaJQjh9D7Db5Aiq8MRghj3+MH57g==",
-          "dev": true,
-          "requires": {
-            "@babel/types": "7.0.0-beta.56"
-          }
-        },
-        "@babel/highlight": {
-          "version": "7.0.0-beta.56",
-          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-beta.56.tgz",
-          "integrity": "sha512-q4TfI+jJISul6vVpZJktzH4tupwRiVk6KXRhB8PHqJ7erl966I6ePDXl9mAbE8jMM7YswhnnB0j1SYP7LBVyhg==",
-          "dev": true,
-          "requires": {
-            "chalk": "^2.0.0",
-            "esutils": "^2.0.2",
-            "js-tokens": "^3.0.0"
-          }
-        },
-        "@babel/parser": {
-          "version": "7.0.0-beta.56",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.0.0-beta.56.tgz",
-          "integrity": "sha512-JM0ughhbo+sPXw2Z+SUyowfYrAOhjanzjMshcLswBdXVelJCOeEKe/FqMqPWGVPQr7wByongXIn+MKdCpY7DBw==",
-          "dev": true
-        },
-        "@babel/template": {
-          "version": "7.0.0-beta.56",
-          "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.0.0-beta.56.tgz",
-          "integrity": "sha512-rsR9K18h0oiJTUmS/ICYREbV8qhPTic4SIqDSkzv9xOxupt7dKj8hWmZQLGPySO5x6cdn8py039o1wPQnsEGHg==",
-          "dev": true,
-          "requires": {
-            "@babel/code-frame": "7.0.0-beta.56",
-            "@babel/parser": "7.0.0-beta.56",
-            "@babel/types": "7.0.0-beta.56",
-            "lodash": "^4.17.10"
-          }
-        },
-        "@babel/traverse": {
-          "version": "7.0.0-beta.56",
-          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.0.0-beta.56.tgz",
-          "integrity": "sha512-9WTqtKP2Ll+jG68r+JEecXAbdH/kk5inN1VDSDaTgdYtZ82BYUS9XRWMVpc5HB9LJsu2ZEyUA1cGybID7eeOXA==",
-          "dev": true,
-          "requires": {
-            "@babel/code-frame": "7.0.0-beta.56",
-            "@babel/generator": "7.0.0-beta.56",
-            "@babel/helper-function-name": "7.0.0-beta.56",
-            "@babel/helper-split-export-declaration": "7.0.0-beta.56",
-            "@babel/parser": "7.0.0-beta.56",
-            "@babel/types": "7.0.0-beta.56",
-            "debug": "^3.1.0",
-            "globals": "^11.1.0",
-            "lodash": "^4.17.10"
-          }
-        },
-        "@babel/types": {
-          "version": "7.0.0-beta.56",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.56.tgz",
-          "integrity": "sha512-fRIBeHtKxAD3D1E7hYSpG4MnLt0AfzHHs5gfVclOB0NlfLu3qiWU/IqdbK2ixTK61424iEkV1P/VAzndx6ungA==",
-          "dev": true,
-          "requires": {
-            "esutils": "^2.0.2",
-            "lodash": "^4.17.10",
-            "to-fast-properties": "^2.0.0"
-          }
-        }
+        "@babel/template": "7.0.0-rc.2",
+        "@babel/traverse": "7.0.0-rc.2",
+        "@babel/types": "7.0.0-rc.2"
       }
     },
     "@babel/highlight": {
-      "version": "7.0.0-beta.52",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-beta.52.tgz",
-      "integrity": "sha1-7ySTFDLwYVXnvDnNuKaze0oos9A=",
+      "version": "7.0.0-rc.2",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-rc.2.tgz",
+      "integrity": "sha512-96V6XHAh9XHzjmucShCP8tULwXsC446doZ6REaLVdZDPNj3NsWbsC7OBeY+u6UWiFxHTTv6YmA4Veh4wXuucYw==",
+      "dev": true,
       "requires": {
         "chalk": "^2.0.0",
         "esutils": "^2.0.2",
-        "js-tokens": "^3.0.0"
+        "js-tokens": "^4.0.0"
+      },
+      "dependencies": {
+        "js-tokens": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+          "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+          "dev": true
+        }
       }
     },
     "@babel/parser": {
-      "version": "7.0.0-beta.52",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.0.0-beta.52.tgz",
-      "integrity": "sha1-TpNbYs2b+HK9N7zx9j2C/nsCN6I="
+      "version": "7.0.0-rc.2",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.0.0-rc.2.tgz",
+      "integrity": "sha512-zDB1QPgQWYwuJty3Ymbx1hq7zbBEbZjTprHOhforvzyQFV86LNh6FS0InjnOUXM6p6QUyONz8KTt/v+MRMd0Hg==",
+      "dev": true
     },
     "@babel/plugin-proposal-async-generator-functions": {
-      "version": "7.0.0-beta.56",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.0.0-beta.56.tgz",
-      "integrity": "sha512-2amegw5EfeOJO5un5+A5cZ7cELUKf7fUzdryFdkg3ciGyNA+ISK9x4B57N8Jb5gWXch1xNsOV7tJuaaWeqbJ3g==",
+      "version": "7.0.0-rc.2",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.0.0-rc.2.tgz",
+      "integrity": "sha512-t2Cgx5Xwsxn7EBEmmrUWW8g9+12sbYHAPa0kAiiQa/hHTPrxnF9y4Kxsvk2VvAhaFzIFzSNSpq3jJvEQ5K8SWw==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.56",
-        "@babel/helper-remap-async-to-generator": "7.0.0-beta.56",
-        "@babel/plugin-syntax-async-generators": "7.0.0-beta.56"
-      },
-      "dependencies": {
-        "@babel/helper-plugin-utils": {
-          "version": "7.0.0-beta.56",
-          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0-beta.56.tgz",
-          "integrity": "sha512-6IlFMU13X7gwnnMldDHwfc7IqngqCH/KfiU7I+GdNoZPnddmjghc87E/zKHaJpWdX1VvXCCelp2EnKq0rgBQ8w==",
-          "dev": true
-        }
+        "@babel/helper-plugin-utils": "7.0.0-rc.2",
+        "@babel/helper-remap-async-to-generator": "7.0.0-rc.2",
+        "@babel/plugin-syntax-async-generators": "7.0.0-rc.2"
       }
     },
     "@babel/plugin-proposal-class-properties": {
-      "version": "7.0.0-beta.56",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.0.0-beta.56.tgz",
-      "integrity": "sha512-OMfd8vJp0lO8cc4RtdtkTJ7nXP0lZlSYLwuX8HPYwd1BIZ00e92z4xzcVGZZCF9BW+Rl9flM9OYwjmlZkcvxyA==",
+      "version": "7.0.0-rc.2",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.0.0-rc.2.tgz",
+      "integrity": "sha512-6hRGHV+UEOHB2FDNbHAXUgTKEMC41Vt8EuG6HIOXLP/shylKryb7a8OPg+EedlYtRJyELD6RlAbl561w1ax3EQ==",
       "dev": true,
       "requires": {
-        "@babel/helper-function-name": "7.0.0-beta.56",
-        "@babel/helper-member-expression-to-functions": "7.0.0-beta.56",
-        "@babel/helper-optimise-call-expression": "7.0.0-beta.56",
-        "@babel/helper-plugin-utils": "7.0.0-beta.56",
-        "@babel/helper-replace-supers": "7.0.0-beta.56",
-        "@babel/plugin-syntax-class-properties": "7.0.0-beta.56"
-      },
-      "dependencies": {
-        "@babel/code-frame": {
-          "version": "7.0.0-beta.56",
-          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.56.tgz",
-          "integrity": "sha512-OBeGs8UXWpKl0oK2T5nUXNl2yu8RKxqL/7aUnMtKDXCU6VUrNP3npdrPivBA11HPB15TVI49nWf2lntTzoUuAg==",
-          "dev": true,
-          "requires": {
-            "@babel/highlight": "7.0.0-beta.56"
-          }
-        },
-        "@babel/helper-function-name": {
-          "version": "7.0.0-beta.56",
-          "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.0.0-beta.56.tgz",
-          "integrity": "sha512-Lq4nPOt1j3sUq+1GVrw57dKq6wBKAHplGjYzEG8dkytqo93i6uSKKKg3smYXx2qohEVD5ciAyJjgRJq7RQu4Lg==",
-          "dev": true,
-          "requires": {
-            "@babel/helper-get-function-arity": "7.0.0-beta.56",
-            "@babel/template": "7.0.0-beta.56",
-            "@babel/types": "7.0.0-beta.56"
-          }
-        },
-        "@babel/helper-get-function-arity": {
-          "version": "7.0.0-beta.56",
-          "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.56.tgz",
-          "integrity": "sha512-QU9EVlnDGTzBasgrdo/I4+RzZS7oqzz9YcetpYko3bp+VsRGokqsAQl3gIvxWTtxwibwboDEdBx+fGArtb2fhw==",
-          "dev": true,
-          "requires": {
-            "@babel/types": "7.0.0-beta.56"
-          }
-        },
-        "@babel/helper-plugin-utils": {
-          "version": "7.0.0-beta.56",
-          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0-beta.56.tgz",
-          "integrity": "sha512-6IlFMU13X7gwnnMldDHwfc7IqngqCH/KfiU7I+GdNoZPnddmjghc87E/zKHaJpWdX1VvXCCelp2EnKq0rgBQ8w==",
-          "dev": true
-        },
-        "@babel/highlight": {
-          "version": "7.0.0-beta.56",
-          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-beta.56.tgz",
-          "integrity": "sha512-q4TfI+jJISul6vVpZJktzH4tupwRiVk6KXRhB8PHqJ7erl966I6ePDXl9mAbE8jMM7YswhnnB0j1SYP7LBVyhg==",
-          "dev": true,
-          "requires": {
-            "chalk": "^2.0.0",
-            "esutils": "^2.0.2",
-            "js-tokens": "^3.0.0"
-          }
-        },
-        "@babel/parser": {
-          "version": "7.0.0-beta.56",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.0.0-beta.56.tgz",
-          "integrity": "sha512-JM0ughhbo+sPXw2Z+SUyowfYrAOhjanzjMshcLswBdXVelJCOeEKe/FqMqPWGVPQr7wByongXIn+MKdCpY7DBw==",
-          "dev": true
-        },
-        "@babel/template": {
-          "version": "7.0.0-beta.56",
-          "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.0.0-beta.56.tgz",
-          "integrity": "sha512-rsR9K18h0oiJTUmS/ICYREbV8qhPTic4SIqDSkzv9xOxupt7dKj8hWmZQLGPySO5x6cdn8py039o1wPQnsEGHg==",
-          "dev": true,
-          "requires": {
-            "@babel/code-frame": "7.0.0-beta.56",
-            "@babel/parser": "7.0.0-beta.56",
-            "@babel/types": "7.0.0-beta.56",
-            "lodash": "^4.17.10"
-          }
-        },
-        "@babel/types": {
-          "version": "7.0.0-beta.56",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.56.tgz",
-          "integrity": "sha512-fRIBeHtKxAD3D1E7hYSpG4MnLt0AfzHHs5gfVclOB0NlfLu3qiWU/IqdbK2ixTK61424iEkV1P/VAzndx6ungA==",
-          "dev": true,
-          "requires": {
-            "esutils": "^2.0.2",
-            "lodash": "^4.17.10",
-            "to-fast-properties": "^2.0.0"
-          }
-        }
+        "@babel/helper-function-name": "7.0.0-rc.2",
+        "@babel/helper-member-expression-to-functions": "7.0.0-rc.2",
+        "@babel/helper-optimise-call-expression": "7.0.0-rc.2",
+        "@babel/helper-plugin-utils": "7.0.0-rc.2",
+        "@babel/helper-replace-supers": "7.0.0-rc.2",
+        "@babel/plugin-syntax-class-properties": "7.0.0-rc.2"
+      }
+    },
+    "@babel/plugin-proposal-json-strings": {
+      "version": "7.0.0-rc.2",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-json-strings/-/plugin-proposal-json-strings-7.0.0-rc.2.tgz",
+      "integrity": "sha512-VMkSumDfbzHK61VkkIj/+jQBSnW2+iv1Z82aJacgQWF+xiwGmaCr/nrEBjZGi4PuAfFJm9b/35bw3imF3xnzWg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "7.0.0-rc.2",
+        "@babel/plugin-syntax-json-strings": "7.0.0-rc.2"
       }
     },
     "@babel/plugin-proposal-object-rest-spread": {
-      "version": "7.0.0-beta.56",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.0.0-beta.56.tgz",
-      "integrity": "sha512-onVk2kI39dzkDP+SzX6eC3nAkq5yemiiZX+AuXAmshOyuz+ZYUu5b+zzXKw0oPFTSnMnlIfJItQCcVzesXcU6A==",
+      "version": "7.0.0-rc.2",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.0.0-rc.2.tgz",
+      "integrity": "sha512-WYF4Pe5qwxWGfbjacz7XCfjlgI6eDyWhCFoWFeAwGVX+43INjKCMt3S+4AzfBYb2wlRh1omzBpUmgGfq1isYUg==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.56",
-        "@babel/plugin-syntax-object-rest-spread": "7.0.0-beta.56"
-      },
-      "dependencies": {
-        "@babel/helper-plugin-utils": {
-          "version": "7.0.0-beta.56",
-          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0-beta.56.tgz",
-          "integrity": "sha512-6IlFMU13X7gwnnMldDHwfc7IqngqCH/KfiU7I+GdNoZPnddmjghc87E/zKHaJpWdX1VvXCCelp2EnKq0rgBQ8w==",
-          "dev": true
-        }
+        "@babel/helper-plugin-utils": "7.0.0-rc.2",
+        "@babel/plugin-syntax-object-rest-spread": "7.0.0-rc.2"
       }
     },
     "@babel/plugin-proposal-optional-catch-binding": {
-      "version": "7.0.0-beta.56",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-catch-binding/-/plugin-proposal-optional-catch-binding-7.0.0-beta.56.tgz",
-      "integrity": "sha512-qLUAi1k8kTiFDUfGkjtdWujo6hTcqCDRw9hvBSxgJ150fRytyCG0pDqmC3KXytSdPPxuAcCCbgB+9CZsGPXkIA==",
+      "version": "7.0.0-rc.2",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-catch-binding/-/plugin-proposal-optional-catch-binding-7.0.0-rc.2.tgz",
+      "integrity": "sha512-s/gOdmc6im0RTIe93FKCCyIFRQy+0BbUQfl7tclpmqU2F9UnjuVBlVqQMyV2HXhlAq5cEoKM5VuVflcndtL1ow==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.56",
-        "@babel/plugin-syntax-optional-catch-binding": "7.0.0-beta.56"
-      },
-      "dependencies": {
-        "@babel/helper-plugin-utils": {
-          "version": "7.0.0-beta.56",
-          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0-beta.56.tgz",
-          "integrity": "sha512-6IlFMU13X7gwnnMldDHwfc7IqngqCH/KfiU7I+GdNoZPnddmjghc87E/zKHaJpWdX1VvXCCelp2EnKq0rgBQ8w==",
-          "dev": true
-        }
+        "@babel/helper-plugin-utils": "7.0.0-rc.2",
+        "@babel/plugin-syntax-optional-catch-binding": "7.0.0-rc.2"
       }
     },
     "@babel/plugin-proposal-unicode-property-regex": {
-      "version": "7.0.0-beta.56",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.0.0-beta.56.tgz",
-      "integrity": "sha512-YszvYRt3tgCTJ+qcBSRKpJhlsiM0/BPcehwHgFzyKi0arnRX7jO8iyTZD3VpkVBElTGTbz91G9fSXj/7Y3PdQw==",
+      "version": "7.0.0-rc.2",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.0.0-rc.2.tgz",
+      "integrity": "sha512-nb6BL9jdAi7t7QV9fGj3ttJwhX4kez2rMiqiVeSAL+NOVfmE4dwkMJ4LliN3gg/ESktsEOQeWXv4rik4q9T9Ug==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.56",
-        "@babel/helper-regex": "7.0.0-beta.56",
+        "@babel/helper-plugin-utils": "7.0.0-rc.2",
+        "@babel/helper-regex": "7.0.0-rc.2",
         "regexpu-core": "^4.2.0"
-      },
-      "dependencies": {
-        "@babel/helper-plugin-utils": {
-          "version": "7.0.0-beta.56",
-          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0-beta.56.tgz",
-          "integrity": "sha512-6IlFMU13X7gwnnMldDHwfc7IqngqCH/KfiU7I+GdNoZPnddmjghc87E/zKHaJpWdX1VvXCCelp2EnKq0rgBQ8w==",
-          "dev": true
-        }
       }
     },
     "@babel/plugin-syntax-async-generators": {
-      "version": "7.0.0-beta.56",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.0.0-beta.56.tgz",
-      "integrity": "sha512-tC8sGd1RridRn0147GUh2rF1WB+8FnP0siTD0ofuqLYJEbOTYn9NF0WD4DNzwwHwOZMBxgHFy8N/B1sNmEC8SQ==",
+      "version": "7.0.0-rc.2",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.0.0-rc.2.tgz",
+      "integrity": "sha512-ZG9eCI+3RJVYZL/i794SsW0gFXj75nF+Kk14XvhxyvVAiT7DP1z+iMcNckr0dzZ4pvEymVCVxkU++X1dkgQQow==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.56"
-      },
-      "dependencies": {
-        "@babel/helper-plugin-utils": {
-          "version": "7.0.0-beta.56",
-          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0-beta.56.tgz",
-          "integrity": "sha512-6IlFMU13X7gwnnMldDHwfc7IqngqCH/KfiU7I+GdNoZPnddmjghc87E/zKHaJpWdX1VvXCCelp2EnKq0rgBQ8w==",
-          "dev": true
-        }
+        "@babel/helper-plugin-utils": "7.0.0-rc.2"
       }
     },
     "@babel/plugin-syntax-class-properties": {
-      "version": "7.0.0-beta.56",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.0.0-beta.56.tgz",
-      "integrity": "sha512-7aq+tQjiOb6pNl5sFn1lSi6sM+LIWw4eRocFZKhbr1GX9hW9I8jV9G+lxvfswiKniyYRyeAua7yIz/VuCH/tfQ==",
+      "version": "7.0.0-rc.2",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.0.0-rc.2.tgz",
+      "integrity": "sha512-+keEGhwq+H6b/FiYXMq7vthTHs24L+KWr6kU3mpNXdUJMGCgAMHkZHCGlMFeZI5ScgrelhjaWUOc+hT2Je7qgw==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.56"
-      },
-      "dependencies": {
-        "@babel/helper-plugin-utils": {
-          "version": "7.0.0-beta.56",
-          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0-beta.56.tgz",
-          "integrity": "sha512-6IlFMU13X7gwnnMldDHwfc7IqngqCH/KfiU7I+GdNoZPnddmjghc87E/zKHaJpWdX1VvXCCelp2EnKq0rgBQ8w==",
-          "dev": true
-        }
+        "@babel/helper-plugin-utils": "7.0.0-rc.2"
       }
     },
     "@babel/plugin-syntax-dynamic-import": {
@@ -1516,702 +376,297 @@
       "integrity": "sha1-otnH3hPfn4wlm17L0VgqrgHOIHc=",
       "requires": {
         "@babel/helper-plugin-utils": "7.0.0-beta.52"
+      },
+      "dependencies": {
+        "@babel/helper-plugin-utils": {
+          "version": "7.0.0-beta.52",
+          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0-beta.52.tgz",
+          "integrity": "sha1-LwWMX3w6X+S8IZA2sueOEb3et60="
+        }
       }
     },
-    "@babel/plugin-syntax-flow": {
-      "version": "7.0.0-beta.52",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-flow/-/plugin-syntax-flow-7.0.0-beta.52.tgz",
-      "integrity": "sha1-gSXB3hWzUstx9uIiAPiIpUZ3LIw=",
+    "@babel/plugin-syntax-json-strings": {
+      "version": "7.0.0-rc.2",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.0.0-rc.2.tgz",
+      "integrity": "sha512-CvojPyEfHjkwwHJATQe/x7F3xBuaB3wfVkOAvsnvGiLTnUDx2E1kYPsvPGoEfWgdS1zkLGlwtPH621bS3rYKQQ==",
+      "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.52"
+        "@babel/helper-plugin-utils": "7.0.0-rc.2"
       }
     },
     "@babel/plugin-syntax-jsx": {
-      "version": "7.0.0-beta.56",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.0.0-beta.56.tgz",
-      "integrity": "sha512-QsZbghj9DemNxr6ZX7V1ULukXrb+d3kRAU9ErikMnSCx60tKW5MQCIuSnHjr1l5wU4XlAZT2qclb+RYTTz0rAw==",
+      "version": "7.0.0-rc.2",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.0.0-rc.2.tgz",
+      "integrity": "sha512-iReV06m3hBc/RyD85vtHNNcYz4wqf0jPUFzUR+yAkzbhupYclHf6Eecse3GMWSNS3sVNMDA/+hCFcgMni41Dwg==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.56"
-      },
-      "dependencies": {
-        "@babel/helper-plugin-utils": {
-          "version": "7.0.0-beta.56",
-          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0-beta.56.tgz",
-          "integrity": "sha512-6IlFMU13X7gwnnMldDHwfc7IqngqCH/KfiU7I+GdNoZPnddmjghc87E/zKHaJpWdX1VvXCCelp2EnKq0rgBQ8w==",
-          "dev": true
-        }
+        "@babel/helper-plugin-utils": "7.0.0-rc.2"
       }
     },
     "@babel/plugin-syntax-object-rest-spread": {
-      "version": "7.0.0-beta.56",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.0.0-beta.56.tgz",
-      "integrity": "sha512-rDqe3TN5cZaUg4zi3Kzfq5qySS6IcEs19WE7GHlmelgQ1QXy9d/tsPEAWHZTLrG4mjbbEFJZdLvAi+LSGdhJAQ==",
+      "version": "7.0.0-rc.2",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.0.0-rc.2.tgz",
+      "integrity": "sha512-TcwJSyWkA5ruAuWhJvmj7N9gmiHTGAz44Rqr6Fgkf6fhdlEYcBHRQQvYEKcYyPLLpqgWCqFvfiW7HgfqkCCe3A==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.56"
-      },
-      "dependencies": {
-        "@babel/helper-plugin-utils": {
-          "version": "7.0.0-beta.56",
-          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0-beta.56.tgz",
-          "integrity": "sha512-6IlFMU13X7gwnnMldDHwfc7IqngqCH/KfiU7I+GdNoZPnddmjghc87E/zKHaJpWdX1VvXCCelp2EnKq0rgBQ8w==",
-          "dev": true
-        }
+        "@babel/helper-plugin-utils": "7.0.0-rc.2"
       }
     },
     "@babel/plugin-syntax-optional-catch-binding": {
-      "version": "7.0.0-beta.56",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.0.0-beta.56.tgz",
-      "integrity": "sha512-rpXmUoqQRwV3QaRUIwKTrVh/pzYe1mMmV43TXJNkP3BX4phimxsF+/orJY8MjqZs9QfHwQkfyb+b6BURLY62kA==",
+      "version": "7.0.0-rc.2",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.0.0-rc.2.tgz",
+      "integrity": "sha512-uZyLBqAFX4142Thord85PcTxD3nTiQE+0BiBL1rHMGc7ln63Auj/EJoWdYa9reb7Bax7OcuwY1lhDbxrgKUYiA==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.56"
-      },
-      "dependencies": {
-        "@babel/helper-plugin-utils": {
-          "version": "7.0.0-beta.56",
-          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0-beta.56.tgz",
-          "integrity": "sha512-6IlFMU13X7gwnnMldDHwfc7IqngqCH/KfiU7I+GdNoZPnddmjghc87E/zKHaJpWdX1VvXCCelp2EnKq0rgBQ8w==",
-          "dev": true
-        }
+        "@babel/helper-plugin-utils": "7.0.0-rc.2"
       }
     },
     "@babel/plugin-transform-arrow-functions": {
-      "version": "7.0.0-beta.56",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.0.0-beta.56.tgz",
-      "integrity": "sha512-TkpqdTt8ivvNBoawwxwFJSHRAQAWvWRuMyQIJfdrmSGdHVaEJ8xn1MkYuORMOogtpsG+ZncmGRAyCEQeMFBPsA==",
+      "version": "7.0.0-rc.2",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.0.0-rc.2.tgz",
+      "integrity": "sha512-wCZZpEfjPBiO7kRLzLLxcaImgHzlrJKjl5pHpTbng+btsCb53hNgE0dm8ph/YRRHv0NdGej0Mo3+kKNJHARjYg==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.56"
-      },
-      "dependencies": {
-        "@babel/helper-plugin-utils": {
-          "version": "7.0.0-beta.56",
-          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0-beta.56.tgz",
-          "integrity": "sha512-6IlFMU13X7gwnnMldDHwfc7IqngqCH/KfiU7I+GdNoZPnddmjghc87E/zKHaJpWdX1VvXCCelp2EnKq0rgBQ8w==",
-          "dev": true
-        }
+        "@babel/helper-plugin-utils": "7.0.0-rc.2"
       }
     },
     "@babel/plugin-transform-async-to-generator": {
-      "version": "7.0.0-beta.56",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.0.0-beta.56.tgz",
-      "integrity": "sha512-n34TSk3nFLCnsuC5f2PSb+jdOVXv1UzENnGN/Xu9/epSFVVNLfNR2td0Gx0Rh4CjIef5JZ0tFounyPWWMSh/0Q==",
+      "version": "7.0.0-rc.2",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.0.0-rc.2.tgz",
+      "integrity": "sha512-NIRF0AbXilqtr8VuTNqhQUgKGeOVu2AosUxJxAQ0e0NaxnNMRWdVTVj4p/Pl1FuSuA5oftDbSGeQYi3VOFktpg==",
       "dev": true,
       "requires": {
-        "@babel/helper-module-imports": "7.0.0-beta.56",
-        "@babel/helper-plugin-utils": "7.0.0-beta.56",
-        "@babel/helper-remap-async-to-generator": "7.0.0-beta.56"
-      },
-      "dependencies": {
-        "@babel/helper-module-imports": {
-          "version": "7.0.0-beta.56",
-          "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.0.0-beta.56.tgz",
-          "integrity": "sha512-iVWFscU+yIu6DIo5IWkMgVXd74/d3z/ZomwF/QJNGFwFP/lNA282rpjsky56fSxS7oT7wAlXoYoHVCOOaL7tbg==",
-          "dev": true,
-          "requires": {
-            "@babel/types": "7.0.0-beta.56",
-            "lodash": "^4.17.10"
-          }
-        },
-        "@babel/helper-plugin-utils": {
-          "version": "7.0.0-beta.56",
-          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0-beta.56.tgz",
-          "integrity": "sha512-6IlFMU13X7gwnnMldDHwfc7IqngqCH/KfiU7I+GdNoZPnddmjghc87E/zKHaJpWdX1VvXCCelp2EnKq0rgBQ8w==",
-          "dev": true
-        },
-        "@babel/types": {
-          "version": "7.0.0-beta.56",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.56.tgz",
-          "integrity": "sha512-fRIBeHtKxAD3D1E7hYSpG4MnLt0AfzHHs5gfVclOB0NlfLu3qiWU/IqdbK2ixTK61424iEkV1P/VAzndx6ungA==",
-          "dev": true,
-          "requires": {
-            "esutils": "^2.0.2",
-            "lodash": "^4.17.10",
-            "to-fast-properties": "^2.0.0"
-          }
-        }
+        "@babel/helper-module-imports": "7.0.0-rc.2",
+        "@babel/helper-plugin-utils": "7.0.0-rc.2",
+        "@babel/helper-remap-async-to-generator": "7.0.0-rc.2"
       }
     },
     "@babel/plugin-transform-block-scoped-functions": {
-      "version": "7.0.0-beta.56",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.0.0-beta.56.tgz",
-      "integrity": "sha512-rgabVaR9M5c7xyuWFMyPN8vT8QkncF9skgA2/O6seiGX8mgl/WjDMkWi2Sm9PFdPc7WEryKh8Rlu/tgupulwSA==",
+      "version": "7.0.0-rc.2",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.0.0-rc.2.tgz",
+      "integrity": "sha512-l2vetC7pegLd1yhDf0uMQsHpACTqBHqiVB5TaMpiGk7Ixz5qS5R4IXdl2hoSAi6ytAAs7VPRtsWrLqfXgjWYwQ==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.56"
-      },
-      "dependencies": {
-        "@babel/helper-plugin-utils": {
-          "version": "7.0.0-beta.56",
-          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0-beta.56.tgz",
-          "integrity": "sha512-6IlFMU13X7gwnnMldDHwfc7IqngqCH/KfiU7I+GdNoZPnddmjghc87E/zKHaJpWdX1VvXCCelp2EnKq0rgBQ8w==",
-          "dev": true
-        }
+        "@babel/helper-plugin-utils": "7.0.0-rc.2"
       }
     },
     "@babel/plugin-transform-block-scoping": {
-      "version": "7.0.0-beta.56",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.0.0-beta.56.tgz",
-      "integrity": "sha512-hqeciuZPUfsZIhJ6MaB68U3+G5eS12ahidn98oUxyOl+BnS/aN9EhSt877mJPlEBe3oQy35qNwg/HG3rq33O2A==",
+      "version": "7.0.0-rc.2",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.0.0-rc.2.tgz",
+      "integrity": "sha512-bJ8717eZ0Y3oY8t5qnCS0f9AQd6aDt5gJiNjqtEYs9OZkwxKfcadnRuIiC49UdfrgbNqVPbXHz/y6ueJiLtheA==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.56",
+        "@babel/helper-plugin-utils": "7.0.0-rc.2",
         "lodash": "^4.17.10"
-      },
-      "dependencies": {
-        "@babel/helper-plugin-utils": {
-          "version": "7.0.0-beta.56",
-          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0-beta.56.tgz",
-          "integrity": "sha512-6IlFMU13X7gwnnMldDHwfc7IqngqCH/KfiU7I+GdNoZPnddmjghc87E/zKHaJpWdX1VvXCCelp2EnKq0rgBQ8w==",
-          "dev": true
-        }
       }
     },
     "@babel/plugin-transform-classes": {
-      "version": "7.0.0-beta.56",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.0.0-beta.56.tgz",
-      "integrity": "sha512-uq0Nvjlkt5gpF+dlvJ1yOZu8liBfOp3QoA/hrP7LZ6XzmYwZOhIUpUbouvKjgvybWiDmNDGcELeC96CL/mtV5Q==",
+      "version": "7.0.0-rc.2",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.0.0-rc.2.tgz",
+      "integrity": "sha512-VGLIza5QhmNBuSQ7wRYl5vSjjb1jdYIJcJsJ7Kgv5QvAasFbjjVAhqiv3/LJae7IJqetjNYN9V+2Bec64399tw==",
       "dev": true,
       "requires": {
-        "@babel/helper-annotate-as-pure": "7.0.0-beta.56",
-        "@babel/helper-define-map": "7.0.0-beta.56",
-        "@babel/helper-function-name": "7.0.0-beta.56",
-        "@babel/helper-optimise-call-expression": "7.0.0-beta.56",
-        "@babel/helper-plugin-utils": "7.0.0-beta.56",
-        "@babel/helper-replace-supers": "7.0.0-beta.56",
-        "@babel/helper-split-export-declaration": "7.0.0-beta.56",
+        "@babel/helper-annotate-as-pure": "7.0.0-rc.2",
+        "@babel/helper-define-map": "7.0.0-rc.2",
+        "@babel/helper-function-name": "7.0.0-rc.2",
+        "@babel/helper-optimise-call-expression": "7.0.0-rc.2",
+        "@babel/helper-plugin-utils": "7.0.0-rc.2",
+        "@babel/helper-replace-supers": "7.0.0-rc.2",
+        "@babel/helper-split-export-declaration": "7.0.0-rc.2",
         "globals": "^11.1.0"
-      },
-      "dependencies": {
-        "@babel/code-frame": {
-          "version": "7.0.0-beta.56",
-          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.56.tgz",
-          "integrity": "sha512-OBeGs8UXWpKl0oK2T5nUXNl2yu8RKxqL/7aUnMtKDXCU6VUrNP3npdrPivBA11HPB15TVI49nWf2lntTzoUuAg==",
-          "dev": true,
-          "requires": {
-            "@babel/highlight": "7.0.0-beta.56"
-          }
-        },
-        "@babel/helper-function-name": {
-          "version": "7.0.0-beta.56",
-          "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.0.0-beta.56.tgz",
-          "integrity": "sha512-Lq4nPOt1j3sUq+1GVrw57dKq6wBKAHplGjYzEG8dkytqo93i6uSKKKg3smYXx2qohEVD5ciAyJjgRJq7RQu4Lg==",
-          "dev": true,
-          "requires": {
-            "@babel/helper-get-function-arity": "7.0.0-beta.56",
-            "@babel/template": "7.0.0-beta.56",
-            "@babel/types": "7.0.0-beta.56"
-          }
-        },
-        "@babel/helper-get-function-arity": {
-          "version": "7.0.0-beta.56",
-          "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.56.tgz",
-          "integrity": "sha512-QU9EVlnDGTzBasgrdo/I4+RzZS7oqzz9YcetpYko3bp+VsRGokqsAQl3gIvxWTtxwibwboDEdBx+fGArtb2fhw==",
-          "dev": true,
-          "requires": {
-            "@babel/types": "7.0.0-beta.56"
-          }
-        },
-        "@babel/helper-plugin-utils": {
-          "version": "7.0.0-beta.56",
-          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0-beta.56.tgz",
-          "integrity": "sha512-6IlFMU13X7gwnnMldDHwfc7IqngqCH/KfiU7I+GdNoZPnddmjghc87E/zKHaJpWdX1VvXCCelp2EnKq0rgBQ8w==",
-          "dev": true
-        },
-        "@babel/helper-split-export-declaration": {
-          "version": "7.0.0-beta.56",
-          "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0-beta.56.tgz",
-          "integrity": "sha512-j886mQJQg5HDF7X0qK/AfNdrpIYUcJHxRKwBJ9dUvhpO3eFqsTLbJJpitgLaJQjh9D7Db5Aiq8MRghj3+MH57g==",
-          "dev": true,
-          "requires": {
-            "@babel/types": "7.0.0-beta.56"
-          }
-        },
-        "@babel/highlight": {
-          "version": "7.0.0-beta.56",
-          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-beta.56.tgz",
-          "integrity": "sha512-q4TfI+jJISul6vVpZJktzH4tupwRiVk6KXRhB8PHqJ7erl966I6ePDXl9mAbE8jMM7YswhnnB0j1SYP7LBVyhg==",
-          "dev": true,
-          "requires": {
-            "chalk": "^2.0.0",
-            "esutils": "^2.0.2",
-            "js-tokens": "^3.0.0"
-          }
-        },
-        "@babel/parser": {
-          "version": "7.0.0-beta.56",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.0.0-beta.56.tgz",
-          "integrity": "sha512-JM0ughhbo+sPXw2Z+SUyowfYrAOhjanzjMshcLswBdXVelJCOeEKe/FqMqPWGVPQr7wByongXIn+MKdCpY7DBw==",
-          "dev": true
-        },
-        "@babel/template": {
-          "version": "7.0.0-beta.56",
-          "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.0.0-beta.56.tgz",
-          "integrity": "sha512-rsR9K18h0oiJTUmS/ICYREbV8qhPTic4SIqDSkzv9xOxupt7dKj8hWmZQLGPySO5x6cdn8py039o1wPQnsEGHg==",
-          "dev": true,
-          "requires": {
-            "@babel/code-frame": "7.0.0-beta.56",
-            "@babel/parser": "7.0.0-beta.56",
-            "@babel/types": "7.0.0-beta.56",
-            "lodash": "^4.17.10"
-          }
-        },
-        "@babel/types": {
-          "version": "7.0.0-beta.56",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.56.tgz",
-          "integrity": "sha512-fRIBeHtKxAD3D1E7hYSpG4MnLt0AfzHHs5gfVclOB0NlfLu3qiWU/IqdbK2ixTK61424iEkV1P/VAzndx6ungA==",
-          "dev": true,
-          "requires": {
-            "esutils": "^2.0.2",
-            "lodash": "^4.17.10",
-            "to-fast-properties": "^2.0.0"
-          }
-        }
       }
     },
     "@babel/plugin-transform-computed-properties": {
-      "version": "7.0.0-beta.56",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.0.0-beta.56.tgz",
-      "integrity": "sha512-U0iHc3aEhgJsW5toS4ZjwWp9bV1l+gsJAt4PI/fXA4XK0DVZEZS82Xq3ozHLp5ccWiqJCCEWYAFys2c/ZPKmjA==",
+      "version": "7.0.0-rc.2",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.0.0-rc.2.tgz",
+      "integrity": "sha512-XZMHsEAM0KRcvEWHIO/5r8kUrPTFlb4oSKf771dlfA7Hfg60YFY8S4UDGmL6Fw5qBn1j0E9pbDoJ5V/MVeU7hA==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.56"
-      },
-      "dependencies": {
-        "@babel/helper-plugin-utils": {
-          "version": "7.0.0-beta.56",
-          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0-beta.56.tgz",
-          "integrity": "sha512-6IlFMU13X7gwnnMldDHwfc7IqngqCH/KfiU7I+GdNoZPnddmjghc87E/zKHaJpWdX1VvXCCelp2EnKq0rgBQ8w==",
-          "dev": true
-        }
+        "@babel/helper-plugin-utils": "7.0.0-rc.2"
       }
     },
     "@babel/plugin-transform-destructuring": {
-      "version": "7.0.0-beta.56",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.0.0-beta.56.tgz",
-      "integrity": "sha512-6Jyis4rwPNQ9a8t1PerzymtC0qfgKlI9SOc44xaZfVo2nxzhb09nXrGsjpXywZVepDUWKHXy17XT0ouiQJmrTw==",
+      "version": "7.0.0-rc.2",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.0.0-rc.2.tgz",
+      "integrity": "sha512-fmtP2ZOtXQGv2ncSZtGzWL/cz5aevgKjvVrdz9t3dPHkyX2CTDBdtJWNds6XLFPkWuN4ayjCbVp7z70Pl98dMg==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.56"
-      },
-      "dependencies": {
-        "@babel/helper-plugin-utils": {
-          "version": "7.0.0-beta.56",
-          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0-beta.56.tgz",
-          "integrity": "sha512-6IlFMU13X7gwnnMldDHwfc7IqngqCH/KfiU7I+GdNoZPnddmjghc87E/zKHaJpWdX1VvXCCelp2EnKq0rgBQ8w==",
-          "dev": true
-        }
+        "@babel/helper-plugin-utils": "7.0.0-rc.2"
       }
     },
     "@babel/plugin-transform-dotall-regex": {
-      "version": "7.0.0-beta.56",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.0.0-beta.56.tgz",
-      "integrity": "sha512-nM7ZXzwdDwviGUleCdDrQ4fGXtTkEFg0HHbZ5LD7XlJrN4goJmi6xHBOoZ8iWdTPrzAuDi+FT87RWCHFDcU4xA==",
+      "version": "7.0.0-rc.2",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.0.0-rc.2.tgz",
+      "integrity": "sha512-BCeZNoleLez7Rg0+iLKK+dqCJDGufKUPISRZr8e6NvSjwwRvovQuNMtdj4Dxww9Xk8zz0e9eKyf2Dt/h9CyECQ==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.56",
-        "@babel/helper-regex": "7.0.0-beta.56",
+        "@babel/helper-plugin-utils": "7.0.0-rc.2",
+        "@babel/helper-regex": "7.0.0-rc.2",
         "regexpu-core": "^4.1.3"
-      },
-      "dependencies": {
-        "@babel/helper-plugin-utils": {
-          "version": "7.0.0-beta.56",
-          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0-beta.56.tgz",
-          "integrity": "sha512-6IlFMU13X7gwnnMldDHwfc7IqngqCH/KfiU7I+GdNoZPnddmjghc87E/zKHaJpWdX1VvXCCelp2EnKq0rgBQ8w==",
-          "dev": true
-        }
       }
     },
     "@babel/plugin-transform-duplicate-keys": {
-      "version": "7.0.0-beta.56",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.0.0-beta.56.tgz",
-      "integrity": "sha512-hnMT8itOVeLuLGtuE+SBpaCyLj97nq2LJwu2Ud6O6Nag1iswDp2MMgTYmFPzPF465LuP4cUp5bmjZcOvFkkoHQ==",
+      "version": "7.0.0-rc.2",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.0.0-rc.2.tgz",
+      "integrity": "sha512-CeEHFlCgeZAb57buALjNFmOYgfblKuQBK2ti09nk2PkhJE3+uf1LbCrLra9sU90lOl474AinQqwkmYyogmkjkw==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.56"
-      },
-      "dependencies": {
-        "@babel/helper-plugin-utils": {
-          "version": "7.0.0-beta.56",
-          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0-beta.56.tgz",
-          "integrity": "sha512-6IlFMU13X7gwnnMldDHwfc7IqngqCH/KfiU7I+GdNoZPnddmjghc87E/zKHaJpWdX1VvXCCelp2EnKq0rgBQ8w==",
-          "dev": true
-        }
+        "@babel/helper-plugin-utils": "7.0.0-rc.2"
       }
     },
     "@babel/plugin-transform-exponentiation-operator": {
-      "version": "7.0.0-beta.56",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.0.0-beta.56.tgz",
-      "integrity": "sha512-t32wjgnTXwOMDd8cIUSpYu3k31EqrYTJsZf/Dw44RDT6EXJzeTKchMsvwd2n8vf02OzjO0a9/qXF5dKl4cK0HQ==",
+      "version": "7.0.0-rc.2",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.0.0-rc.2.tgz",
+      "integrity": "sha512-VnotPddF7jLAQK6QgBNNwzhPUsxxullq+BEFaDKi1zvXnNGqOcgJ+fmemrdfGUoZWV82Zv2aRehwswPkxPcK2w==",
       "dev": true,
       "requires": {
-        "@babel/helper-builder-binary-assignment-operator-visitor": "7.0.0-beta.56",
-        "@babel/helper-plugin-utils": "7.0.0-beta.56"
-      },
-      "dependencies": {
-        "@babel/helper-plugin-utils": {
-          "version": "7.0.0-beta.56",
-          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0-beta.56.tgz",
-          "integrity": "sha512-6IlFMU13X7gwnnMldDHwfc7IqngqCH/KfiU7I+GdNoZPnddmjghc87E/zKHaJpWdX1VvXCCelp2EnKq0rgBQ8w==",
-          "dev": true
-        }
-      }
-    },
-    "@babel/plugin-transform-flow-strip-types": {
-      "version": "7.0.0-beta.52",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-flow-strip-types/-/plugin-transform-flow-strip-types-7.0.0-beta.52.tgz",
-      "integrity": "sha1-Mhwd2EukTuNCn5lce/WM0KurtxQ=",
-      "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.52",
-        "@babel/plugin-syntax-flow": "7.0.0-beta.52"
+        "@babel/helper-builder-binary-assignment-operator-visitor": "7.0.0-rc.2",
+        "@babel/helper-plugin-utils": "7.0.0-rc.2"
       }
     },
     "@babel/plugin-transform-for-of": {
-      "version": "7.0.0-beta.56",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.0.0-beta.56.tgz",
-      "integrity": "sha512-z4sift6xY65vOpFlRyPrcKNgusCV9NZZGOR9Dxt64XUEWnyxpabHZ9mGe0B3mqJbm168cK7sbxruvnyfyrO2fg==",
+      "version": "7.0.0-rc.2",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.0.0-rc.2.tgz",
+      "integrity": "sha512-6alRFzRGQEYlsYsm/WCOZ3+XND9f+/Pj0wkM4+uWPy7lmYoUHLVESGYJc8wFXjk/diNYzjowrx9JZn6sn6lXNw==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.56"
-      },
-      "dependencies": {
-        "@babel/helper-plugin-utils": {
-          "version": "7.0.0-beta.56",
-          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0-beta.56.tgz",
-          "integrity": "sha512-6IlFMU13X7gwnnMldDHwfc7IqngqCH/KfiU7I+GdNoZPnddmjghc87E/zKHaJpWdX1VvXCCelp2EnKq0rgBQ8w==",
-          "dev": true
-        }
+        "@babel/helper-plugin-utils": "7.0.0-rc.2"
       }
     },
     "@babel/plugin-transform-function-name": {
-      "version": "7.0.0-beta.56",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.0.0-beta.56.tgz",
-      "integrity": "sha512-olcHC1WD2L36/vUl/aw5STpv/+O4C/mUGOytQ2NJn0VPKqeaYCBaEboz+4nnttlvTojaxWzBURTl675YvlPcWw==",
+      "version": "7.0.0-rc.2",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.0.0-rc.2.tgz",
+      "integrity": "sha512-UmP+TGefcAAakV54Gs1RPwt0WCD1MogSMlWjEjJXUCrjvWlGGUIlcz5YR2bxtvPHBv3anpt9fxS1LZb0fjd2Mw==",
       "dev": true,
       "requires": {
-        "@babel/helper-function-name": "7.0.0-beta.56",
-        "@babel/helper-plugin-utils": "7.0.0-beta.56"
-      },
-      "dependencies": {
-        "@babel/code-frame": {
-          "version": "7.0.0-beta.56",
-          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.56.tgz",
-          "integrity": "sha512-OBeGs8UXWpKl0oK2T5nUXNl2yu8RKxqL/7aUnMtKDXCU6VUrNP3npdrPivBA11HPB15TVI49nWf2lntTzoUuAg==",
-          "dev": true,
-          "requires": {
-            "@babel/highlight": "7.0.0-beta.56"
-          }
-        },
-        "@babel/helper-function-name": {
-          "version": "7.0.0-beta.56",
-          "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.0.0-beta.56.tgz",
-          "integrity": "sha512-Lq4nPOt1j3sUq+1GVrw57dKq6wBKAHplGjYzEG8dkytqo93i6uSKKKg3smYXx2qohEVD5ciAyJjgRJq7RQu4Lg==",
-          "dev": true,
-          "requires": {
-            "@babel/helper-get-function-arity": "7.0.0-beta.56",
-            "@babel/template": "7.0.0-beta.56",
-            "@babel/types": "7.0.0-beta.56"
-          }
-        },
-        "@babel/helper-get-function-arity": {
-          "version": "7.0.0-beta.56",
-          "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.56.tgz",
-          "integrity": "sha512-QU9EVlnDGTzBasgrdo/I4+RzZS7oqzz9YcetpYko3bp+VsRGokqsAQl3gIvxWTtxwibwboDEdBx+fGArtb2fhw==",
-          "dev": true,
-          "requires": {
-            "@babel/types": "7.0.0-beta.56"
-          }
-        },
-        "@babel/helper-plugin-utils": {
-          "version": "7.0.0-beta.56",
-          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0-beta.56.tgz",
-          "integrity": "sha512-6IlFMU13X7gwnnMldDHwfc7IqngqCH/KfiU7I+GdNoZPnddmjghc87E/zKHaJpWdX1VvXCCelp2EnKq0rgBQ8w==",
-          "dev": true
-        },
-        "@babel/highlight": {
-          "version": "7.0.0-beta.56",
-          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-beta.56.tgz",
-          "integrity": "sha512-q4TfI+jJISul6vVpZJktzH4tupwRiVk6KXRhB8PHqJ7erl966I6ePDXl9mAbE8jMM7YswhnnB0j1SYP7LBVyhg==",
-          "dev": true,
-          "requires": {
-            "chalk": "^2.0.0",
-            "esutils": "^2.0.2",
-            "js-tokens": "^3.0.0"
-          }
-        },
-        "@babel/parser": {
-          "version": "7.0.0-beta.56",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.0.0-beta.56.tgz",
-          "integrity": "sha512-JM0ughhbo+sPXw2Z+SUyowfYrAOhjanzjMshcLswBdXVelJCOeEKe/FqMqPWGVPQr7wByongXIn+MKdCpY7DBw==",
-          "dev": true
-        },
-        "@babel/template": {
-          "version": "7.0.0-beta.56",
-          "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.0.0-beta.56.tgz",
-          "integrity": "sha512-rsR9K18h0oiJTUmS/ICYREbV8qhPTic4SIqDSkzv9xOxupt7dKj8hWmZQLGPySO5x6cdn8py039o1wPQnsEGHg==",
-          "dev": true,
-          "requires": {
-            "@babel/code-frame": "7.0.0-beta.56",
-            "@babel/parser": "7.0.0-beta.56",
-            "@babel/types": "7.0.0-beta.56",
-            "lodash": "^4.17.10"
-          }
-        },
-        "@babel/types": {
-          "version": "7.0.0-beta.56",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.56.tgz",
-          "integrity": "sha512-fRIBeHtKxAD3D1E7hYSpG4MnLt0AfzHHs5gfVclOB0NlfLu3qiWU/IqdbK2ixTK61424iEkV1P/VAzndx6ungA==",
-          "dev": true,
-          "requires": {
-            "esutils": "^2.0.2",
-            "lodash": "^4.17.10",
-            "to-fast-properties": "^2.0.0"
-          }
-        }
+        "@babel/helper-function-name": "7.0.0-rc.2",
+        "@babel/helper-plugin-utils": "7.0.0-rc.2"
       }
     },
     "@babel/plugin-transform-literals": {
-      "version": "7.0.0-beta.56",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.0.0-beta.56.tgz",
-      "integrity": "sha512-uz7Hcui2qmf1fA8pl5CsLz8KjM3HuUbEws/59G9kaMOrSIMrGSfeN1zsthfFSJDpFQLwq5NZ0+lPIvuOwE61bA==",
+      "version": "7.0.0-rc.2",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.0.0-rc.2.tgz",
+      "integrity": "sha512-lW0hoPqS4WhYgSQ0ifNk1tHn+e4OateqWXaM7BW7wZEU0dtP+RQ0x4z5Xghc7u82ZA4IwPN7mS1i201I7eT+dw==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.56"
-      },
-      "dependencies": {
-        "@babel/helper-plugin-utils": {
-          "version": "7.0.0-beta.56",
-          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0-beta.56.tgz",
-          "integrity": "sha512-6IlFMU13X7gwnnMldDHwfc7IqngqCH/KfiU7I+GdNoZPnddmjghc87E/zKHaJpWdX1VvXCCelp2EnKq0rgBQ8w==",
-          "dev": true
-        }
+        "@babel/helper-plugin-utils": "7.0.0-rc.2"
       }
     },
     "@babel/plugin-transform-modules-amd": {
-      "version": "7.0.0-beta.56",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.0.0-beta.56.tgz",
-      "integrity": "sha512-qbYJ9Xfi17D6GWzqs6AIKbT5oN5A4ONwxMzqkvr501ft0JognN4Hc5W5UAyCGdNgY/V6+Qdf1t8Opd+zTcS1FA==",
+      "version": "7.0.0-rc.2",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.0.0-rc.2.tgz",
+      "integrity": "sha512-phr4bjRHDvLv3OK4g0NvT998A19kmqZKMrnOFZC5gvIEvdGCa18y9Y2mZPg2Jxi+tKI1lkh248L0puLUsEtwfw==",
       "dev": true,
       "requires": {
-        "@babel/helper-module-transforms": "7.0.0-beta.56",
-        "@babel/helper-plugin-utils": "7.0.0-beta.56"
-      },
-      "dependencies": {
-        "@babel/helper-plugin-utils": {
-          "version": "7.0.0-beta.56",
-          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0-beta.56.tgz",
-          "integrity": "sha512-6IlFMU13X7gwnnMldDHwfc7IqngqCH/KfiU7I+GdNoZPnddmjghc87E/zKHaJpWdX1VvXCCelp2EnKq0rgBQ8w==",
-          "dev": true
-        }
+        "@babel/helper-module-transforms": "7.0.0-rc.2",
+        "@babel/helper-plugin-utils": "7.0.0-rc.2"
       }
     },
     "@babel/plugin-transform-modules-commonjs": {
-      "version": "7.0.0-beta.56",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.0.0-beta.56.tgz",
-      "integrity": "sha512-48juOe+HB048Km4l7ZzCKptRlfnYGAC5WwPJrDzldHQ8JFFmbrZPoDGPSlDK/3z9JRMldBHioVHvID5WTYPE9g==",
+      "version": "7.0.0-rc.2",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.0.0-rc.2.tgz",
+      "integrity": "sha512-GWwKVT/vqQ9jSXmLPDZXPJkhuJRKyfE+SZkeM8D9EwcZYpy9DLiKFHyLbw5vKW0wHOwovbeD9/0pvPASuT2rAg==",
       "dev": true,
       "requires": {
-        "@babel/helper-module-transforms": "7.0.0-beta.56",
-        "@babel/helper-plugin-utils": "7.0.0-beta.56",
-        "@babel/helper-simple-access": "7.0.0-beta.56"
-      },
-      "dependencies": {
-        "@babel/helper-plugin-utils": {
-          "version": "7.0.0-beta.56",
-          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0-beta.56.tgz",
-          "integrity": "sha512-6IlFMU13X7gwnnMldDHwfc7IqngqCH/KfiU7I+GdNoZPnddmjghc87E/zKHaJpWdX1VvXCCelp2EnKq0rgBQ8w==",
-          "dev": true
-        }
+        "@babel/helper-module-transforms": "7.0.0-rc.2",
+        "@babel/helper-plugin-utils": "7.0.0-rc.2",
+        "@babel/helper-simple-access": "7.0.0-rc.2"
       }
     },
     "@babel/plugin-transform-modules-systemjs": {
-      "version": "7.0.0-beta.56",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.0.0-beta.56.tgz",
-      "integrity": "sha512-tr2KAI4jhBfZLkSIHU4vlS6I1RmFYfMxM49ese+iPryvj1aH7x1VSz2+DEA/Xr+gM4CTXpWk0Xf2r2u260lPEA==",
+      "version": "7.0.0-rc.2",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.0.0-rc.2.tgz",
+      "integrity": "sha512-uIDk/4+OzSSrW9whicWupSfcfDixWUxppUCkPEHBA3UKMNSo7ageneh+35rWKDvZh3f+DrgJxbDfyolFBsr7kg==",
       "dev": true,
       "requires": {
-        "@babel/helper-hoist-variables": "7.0.0-beta.56",
-        "@babel/helper-plugin-utils": "7.0.0-beta.56"
-      },
-      "dependencies": {
-        "@babel/helper-plugin-utils": {
-          "version": "7.0.0-beta.56",
-          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0-beta.56.tgz",
-          "integrity": "sha512-6IlFMU13X7gwnnMldDHwfc7IqngqCH/KfiU7I+GdNoZPnddmjghc87E/zKHaJpWdX1VvXCCelp2EnKq0rgBQ8w==",
-          "dev": true
-        }
+        "@babel/helper-hoist-variables": "7.0.0-rc.2",
+        "@babel/helper-plugin-utils": "7.0.0-rc.2"
       }
     },
     "@babel/plugin-transform-modules-umd": {
-      "version": "7.0.0-beta.56",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.0.0-beta.56.tgz",
-      "integrity": "sha512-0ItEhFLodomK7FH2FgK+UAphXd95UKyj3SXcRRhbUifvpfnqv0QFgaffI01iEyFnbxdXKpZqESHZR1fV/w1igw==",
+      "version": "7.0.0-rc.2",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.0.0-rc.2.tgz",
+      "integrity": "sha512-4gnDpcZ8/F9eoYZlQKAvh5wzax3UQFmZEBMKJabl133iTLb0aXkd+yVJGmn7Vu/+Q8wRH4kkH6Kc2pbsvlbnHQ==",
       "dev": true,
       "requires": {
-        "@babel/helper-module-transforms": "7.0.0-beta.56",
-        "@babel/helper-plugin-utils": "7.0.0-beta.56"
-      },
-      "dependencies": {
-        "@babel/helper-plugin-utils": {
-          "version": "7.0.0-beta.56",
-          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0-beta.56.tgz",
-          "integrity": "sha512-6IlFMU13X7gwnnMldDHwfc7IqngqCH/KfiU7I+GdNoZPnddmjghc87E/zKHaJpWdX1VvXCCelp2EnKq0rgBQ8w==",
-          "dev": true
-        }
+        "@babel/helper-module-transforms": "7.0.0-rc.2",
+        "@babel/helper-plugin-utils": "7.0.0-rc.2"
       }
     },
     "@babel/plugin-transform-new-target": {
-      "version": "7.0.0-beta.56",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.0.0-beta.56.tgz",
-      "integrity": "sha512-8r4H92o1LX6xZ3gGCUwrIiMwEoOfUfbflKOzrNQig2ybhX+9thU63m0P7cIU4qgp60mzIDKj2m7bz17s6MCl5g==",
+      "version": "7.0.0-rc.2",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.0.0-rc.2.tgz",
+      "integrity": "sha512-eZR2hgV0rIDAQIYHihqxbGaGNaci7HIOEcpgN207ytlKr0ynw8QFPLGHcu2HNJ3zPF08LltjlfREqttFbdnYzA==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.56"
-      },
-      "dependencies": {
-        "@babel/helper-plugin-utils": {
-          "version": "7.0.0-beta.56",
-          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0-beta.56.tgz",
-          "integrity": "sha512-6IlFMU13X7gwnnMldDHwfc7IqngqCH/KfiU7I+GdNoZPnddmjghc87E/zKHaJpWdX1VvXCCelp2EnKq0rgBQ8w==",
-          "dev": true
-        }
+        "@babel/helper-plugin-utils": "7.0.0-rc.2"
       }
     },
     "@babel/plugin-transform-object-super": {
-      "version": "7.0.0-beta.56",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.0.0-beta.56.tgz",
-      "integrity": "sha512-GB6OyxC16aIPE7lm13xfUsoP+zoqCn9PaocXzlGbQbotMoQ+qkmv3Ymq/Oy5YQl3kl5xrxX0JKNuOhYUjhG4YQ==",
+      "version": "7.0.0-rc.2",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.0.0-rc.2.tgz",
+      "integrity": "sha512-VuV9E57/MQLLw5uQ1fiVhyC25gTTa+rNUVz6DEzInIV81VFm1KM0U5/b3FgTqtLMMHp/dFDExqwkHjmvlWpdzw==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.56",
-        "@babel/helper-replace-supers": "7.0.0-beta.56"
-      },
-      "dependencies": {
-        "@babel/helper-plugin-utils": {
-          "version": "7.0.0-beta.56",
-          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0-beta.56.tgz",
-          "integrity": "sha512-6IlFMU13X7gwnnMldDHwfc7IqngqCH/KfiU7I+GdNoZPnddmjghc87E/zKHaJpWdX1VvXCCelp2EnKq0rgBQ8w==",
-          "dev": true
-        }
+        "@babel/helper-plugin-utils": "7.0.0-rc.2",
+        "@babel/helper-replace-supers": "7.0.0-rc.2"
       }
     },
     "@babel/plugin-transform-parameters": {
-      "version": "7.0.0-beta.56",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.0.0-beta.56.tgz",
-      "integrity": "sha512-zhGeuH/eY3kDVfFCWpyc1pWoIyuTZghqazsqJkUKwJMHoqVZuwEvNmpPi9Hhbn+W+LOFt8MJv5dY+kgfbMlwAQ==",
+      "version": "7.0.0-rc.2",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.0.0-rc.2.tgz",
+      "integrity": "sha512-jjl/rEU3LAHPWdlNokNex0sOZ6ytEw8+f1tvSZCGuSzmqGZbMreLOLB1HFSKRCsu6zsQNYY/in2h11fgQU40yQ==",
       "dev": true,
       "requires": {
-        "@babel/helper-call-delegate": "7.0.0-beta.56",
-        "@babel/helper-get-function-arity": "7.0.0-beta.56",
-        "@babel/helper-plugin-utils": "7.0.0-beta.56"
-      },
-      "dependencies": {
-        "@babel/helper-get-function-arity": {
-          "version": "7.0.0-beta.56",
-          "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.56.tgz",
-          "integrity": "sha512-QU9EVlnDGTzBasgrdo/I4+RzZS7oqzz9YcetpYko3bp+VsRGokqsAQl3gIvxWTtxwibwboDEdBx+fGArtb2fhw==",
-          "dev": true,
-          "requires": {
-            "@babel/types": "7.0.0-beta.56"
-          }
-        },
-        "@babel/helper-plugin-utils": {
-          "version": "7.0.0-beta.56",
-          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0-beta.56.tgz",
-          "integrity": "sha512-6IlFMU13X7gwnnMldDHwfc7IqngqCH/KfiU7I+GdNoZPnddmjghc87E/zKHaJpWdX1VvXCCelp2EnKq0rgBQ8w==",
-          "dev": true
-        },
-        "@babel/types": {
-          "version": "7.0.0-beta.56",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.56.tgz",
-          "integrity": "sha512-fRIBeHtKxAD3D1E7hYSpG4MnLt0AfzHHs5gfVclOB0NlfLu3qiWU/IqdbK2ixTK61424iEkV1P/VAzndx6ungA==",
-          "dev": true,
-          "requires": {
-            "esutils": "^2.0.2",
-            "lodash": "^4.17.10",
-            "to-fast-properties": "^2.0.0"
-          }
-        }
+        "@babel/helper-call-delegate": "7.0.0-rc.2",
+        "@babel/helper-get-function-arity": "7.0.0-rc.2",
+        "@babel/helper-plugin-utils": "7.0.0-rc.2"
       }
     },
     "@babel/plugin-transform-react-display-name": {
-      "version": "7.0.0-beta.56",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-display-name/-/plugin-transform-react-display-name-7.0.0-beta.56.tgz",
-      "integrity": "sha512-K+MkaS/epgMstmKlUFsm1QxBHm+BTwI5TS5bgHh3M8N9ip4IQKAZacAAmQ6lNioIiO7TjH84qSZtBX+FYCgvtA==",
+      "version": "7.0.0-rc.2",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-display-name/-/plugin-transform-react-display-name-7.0.0-rc.2.tgz",
+      "integrity": "sha512-u2q02Okd6aXMP5Q0DPl5vuIPrXLST1kAVDZG2oT7N8GEN65i2g0NBY01qb3vuI8gvYOw4cVV4YgxoYr4XMylug==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.56"
-      },
-      "dependencies": {
-        "@babel/helper-plugin-utils": {
-          "version": "7.0.0-beta.56",
-          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0-beta.56.tgz",
-          "integrity": "sha512-6IlFMU13X7gwnnMldDHwfc7IqngqCH/KfiU7I+GdNoZPnddmjghc87E/zKHaJpWdX1VvXCCelp2EnKq0rgBQ8w==",
-          "dev": true
-        }
+        "@babel/helper-plugin-utils": "7.0.0-rc.2"
       }
     },
     "@babel/plugin-transform-react-jsx": {
-      "version": "7.0.0-beta.56",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.0.0-beta.56.tgz",
-      "integrity": "sha512-xg1l6yyWxxE4NdCIs+d3xx9Q03BmktxI9fIfxKaT0y+UjABg6J1eGCJRBPa1s3X212gkUcEmYPjG6jo4ew40Sw==",
+      "version": "7.0.0-rc.2",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.0.0-rc.2.tgz",
+      "integrity": "sha512-lxGw4nT8AO0QVdmGdWzi35rZxkTp10+igJZXnp37X7BYTWzap/gayBCvchIT21k1noUowgJoeURPoAFCyIk8kQ==",
       "dev": true,
       "requires": {
-        "@babel/helper-builder-react-jsx": "7.0.0-beta.56",
-        "@babel/helper-plugin-utils": "7.0.0-beta.56",
-        "@babel/plugin-syntax-jsx": "7.0.0-beta.56"
-      },
-      "dependencies": {
-        "@babel/helper-plugin-utils": {
-          "version": "7.0.0-beta.56",
-          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0-beta.56.tgz",
-          "integrity": "sha512-6IlFMU13X7gwnnMldDHwfc7IqngqCH/KfiU7I+GdNoZPnddmjghc87E/zKHaJpWdX1VvXCCelp2EnKq0rgBQ8w==",
-          "dev": true
-        }
+        "@babel/helper-builder-react-jsx": "7.0.0-rc.2",
+        "@babel/helper-plugin-utils": "7.0.0-rc.2",
+        "@babel/plugin-syntax-jsx": "7.0.0-rc.2"
       }
     },
     "@babel/plugin-transform-react-jsx-self": {
-      "version": "7.0.0-beta.56",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.0.0-beta.56.tgz",
-      "integrity": "sha512-drNQEnMMaHaY1jANaMQVO0wRP2yf0nVstf6QHECzlCuOUaXvT7KtTgePv4fcpv2z/WSZCwQTM7ryHpeYobmNNQ==",
+      "version": "7.0.0-rc.2",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.0.0-rc.2.tgz",
+      "integrity": "sha512-recQB7RQJObp6UucFyWN2ykguqVFyFRKELCRP75Ogv43k+Tk0vmk5hjmXeRsyFj8k+kcPss4zqNdYndP8Qdu5A==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.56",
-        "@babel/plugin-syntax-jsx": "7.0.0-beta.56"
-      },
-      "dependencies": {
-        "@babel/helper-plugin-utils": {
-          "version": "7.0.0-beta.56",
-          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0-beta.56.tgz",
-          "integrity": "sha512-6IlFMU13X7gwnnMldDHwfc7IqngqCH/KfiU7I+GdNoZPnddmjghc87E/zKHaJpWdX1VvXCCelp2EnKq0rgBQ8w==",
-          "dev": true
-        }
+        "@babel/helper-plugin-utils": "7.0.0-rc.2",
+        "@babel/plugin-syntax-jsx": "7.0.0-rc.2"
       }
     },
     "@babel/plugin-transform-react-jsx-source": {
-      "version": "7.0.0-beta.56",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.0.0-beta.56.tgz",
-      "integrity": "sha512-HQs16FPkc7B+XjvXLHVX95ouz55AiNPStUgAngeHOjNVq7veZ7CtYP2uzdXWUrl5JsglFeZj8wa3+zUALhhgJA==",
+      "version": "7.0.0-rc.2",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.0.0-rc.2.tgz",
+      "integrity": "sha512-N8eyYdYer44AOf69xS9VK5PpOLXTZrKppFuixmITzDUaQioELFHGwXpGLV6GuPnoS8R//jL8cK7awpo6vYjuug==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.56",
-        "@babel/plugin-syntax-jsx": "7.0.0-beta.56"
-      },
-      "dependencies": {
-        "@babel/helper-plugin-utils": {
-          "version": "7.0.0-beta.56",
-          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0-beta.56.tgz",
-          "integrity": "sha512-6IlFMU13X7gwnnMldDHwfc7IqngqCH/KfiU7I+GdNoZPnddmjghc87E/zKHaJpWdX1VvXCCelp2EnKq0rgBQ8w==",
-          "dev": true
-        }
+        "@babel/helper-plugin-utils": "7.0.0-rc.2",
+        "@babel/plugin-syntax-jsx": "7.0.0-rc.2"
       }
     },
     "@babel/plugin-transform-regenerator": {
-      "version": "7.0.0-beta.56",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.0.0-beta.56.tgz",
-      "integrity": "sha512-wSRlSwXSXlpAdAKethZu+JyrnSL1NvLn3VtomlOCqHWhRhjOkjehIBlAe/AmguSn9JTUja0vqBWn1FS8sSnp7Q==",
+      "version": "7.0.0-rc.2",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.0.0-rc.2.tgz",
+      "integrity": "sha512-t4d/kBjxwLgmLWwI/Kz9CnO4z8rsiQ5dS3EYgGRua4VGkczde6m3jpzZx0+7b6iw+frGI12W27V50D5Ruv5juw==",
       "dev": true,
       "requires": {
         "regenerator-transform": "^0.13.3"
@@ -2224,112 +679,90 @@
       "requires": {
         "@babel/helper-module-imports": "7.0.0-beta.52",
         "@babel/helper-plugin-utils": "7.0.0-beta.52"
+      },
+      "dependencies": {
+        "@babel/helper-module-imports": {
+          "version": "7.0.0-beta.52",
+          "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.0.0-beta.52.tgz",
+          "integrity": "sha1-cIQOg66JH5RwLGxhN4fEjuPJZbs=",
+          "requires": {
+            "@babel/types": "7.0.0-beta.52",
+            "lodash": "^4.17.5"
+          }
+        },
+        "@babel/helper-plugin-utils": {
+          "version": "7.0.0-beta.52",
+          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0-beta.52.tgz",
+          "integrity": "sha1-LwWMX3w6X+S8IZA2sueOEb3et60="
+        },
+        "@babel/types": {
+          "version": "7.0.0-beta.52",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.52.tgz",
+          "integrity": "sha1-o+ViCxU0slOlCrzyIitSDiOxbaI=",
+          "requires": {
+            "esutils": "^2.0.2",
+            "lodash": "^4.17.5",
+            "to-fast-properties": "^2.0.0"
+          }
+        }
       }
     },
     "@babel/plugin-transform-shorthand-properties": {
-      "version": "7.0.0-beta.56",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.0.0-beta.56.tgz",
-      "integrity": "sha512-qfN9LTjglikI4N2K/WkZAJQijWQpsQefsC/sXEN6c4/G9n5ZJFyXt23aXXcjibncKbcTrRpmH0nTeMiZK0A+5A==",
+      "version": "7.0.0-rc.2",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.0.0-rc.2.tgz",
+      "integrity": "sha512-IKkCwaGhfgRTGFrGKCqQmPFm7Z+y4hfzWPgctZNhZFtjPN0Y6B+ixaX7Ey0aFEIq6K+2cAIMiZTJbDflQEb0Fg==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.56"
-      },
-      "dependencies": {
-        "@babel/helper-plugin-utils": {
-          "version": "7.0.0-beta.56",
-          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0-beta.56.tgz",
-          "integrity": "sha512-6IlFMU13X7gwnnMldDHwfc7IqngqCH/KfiU7I+GdNoZPnddmjghc87E/zKHaJpWdX1VvXCCelp2EnKq0rgBQ8w==",
-          "dev": true
-        }
+        "@babel/helper-plugin-utils": "7.0.0-rc.2"
       }
     },
     "@babel/plugin-transform-spread": {
-      "version": "7.0.0-beta.56",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.0.0-beta.56.tgz",
-      "integrity": "sha512-C0EUKGVSU5ttbRe+ATn54oR2jdGzGIA8Uo/0jwtMeTU+6lewpTX8nu+M36JZDIcq2sSu7zxfLiRkErb/PX/Q0g==",
+      "version": "7.0.0-rc.2",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.0.0-rc.2.tgz",
+      "integrity": "sha512-Xmw5FxsvrxHv94j9i54IfIpbNbaGC4TpokMmMjuqdgeezCEZkCFUolqydhgDKgxCg5pqKDh6oDistJIJ/8RLMA==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.56"
-      },
-      "dependencies": {
-        "@babel/helper-plugin-utils": {
-          "version": "7.0.0-beta.56",
-          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0-beta.56.tgz",
-          "integrity": "sha512-6IlFMU13X7gwnnMldDHwfc7IqngqCH/KfiU7I+GdNoZPnddmjghc87E/zKHaJpWdX1VvXCCelp2EnKq0rgBQ8w==",
-          "dev": true
-        }
+        "@babel/helper-plugin-utils": "7.0.0-rc.2"
       }
     },
     "@babel/plugin-transform-sticky-regex": {
-      "version": "7.0.0-beta.56",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.0.0-beta.56.tgz",
-      "integrity": "sha512-VGPxbfefemuJg6/UVXf8WaaU9gIZRr31aLBsjDdYfj41N3W55LSvU+6CxCZ/ID6SfNCcQUEyBtZsWMWvv38Dhw==",
+      "version": "7.0.0-rc.2",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.0.0-rc.2.tgz",
+      "integrity": "sha512-//QPQAuZE6BqOkZNqr2GLfBE0gssKucez91+4wX3f4x0QN9lsMD6fLN5mymnVGWw7FKlM3XuPYEF8syqqJD4Dw==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.56",
-        "@babel/helper-regex": "7.0.0-beta.56"
-      },
-      "dependencies": {
-        "@babel/helper-plugin-utils": {
-          "version": "7.0.0-beta.56",
-          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0-beta.56.tgz",
-          "integrity": "sha512-6IlFMU13X7gwnnMldDHwfc7IqngqCH/KfiU7I+GdNoZPnddmjghc87E/zKHaJpWdX1VvXCCelp2EnKq0rgBQ8w==",
-          "dev": true
-        }
+        "@babel/helper-plugin-utils": "7.0.0-rc.2",
+        "@babel/helper-regex": "7.0.0-rc.2"
       }
     },
     "@babel/plugin-transform-template-literals": {
-      "version": "7.0.0-beta.56",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.0.0-beta.56.tgz",
-      "integrity": "sha512-VMK/94Mlz24KFg0wc4Y4fAM6FNnx0wnr4A36rMdU54SYM3AEYzQcXtbI4uOCUSGdTOKR5zOiwhNnZFRodi29iA==",
+      "version": "7.0.0-rc.2",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.0.0-rc.2.tgz",
+      "integrity": "sha512-6ICqvslFDU6S+zggiF73e9chbb1MicgPMFgnjo3QikfKe0aolOfyoKTcBNRRXywnZr+ILUcY44zkF3jI3mr2Fw==",
       "dev": true,
       "requires": {
-        "@babel/helper-annotate-as-pure": "7.0.0-beta.56",
-        "@babel/helper-plugin-utils": "7.0.0-beta.56"
-      },
-      "dependencies": {
-        "@babel/helper-plugin-utils": {
-          "version": "7.0.0-beta.56",
-          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0-beta.56.tgz",
-          "integrity": "sha512-6IlFMU13X7gwnnMldDHwfc7IqngqCH/KfiU7I+GdNoZPnddmjghc87E/zKHaJpWdX1VvXCCelp2EnKq0rgBQ8w==",
-          "dev": true
-        }
+        "@babel/helper-annotate-as-pure": "7.0.0-rc.2",
+        "@babel/helper-plugin-utils": "7.0.0-rc.2"
       }
     },
     "@babel/plugin-transform-typeof-symbol": {
-      "version": "7.0.0-beta.56",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.0.0-beta.56.tgz",
-      "integrity": "sha512-BnKyH+AUvnVHyl+1Kt40jfr6+0/DUED9huSdirp1DrKwmjlcu4FliGDNcSSKBfawV4covKT7MBjWpE6s+XNk1g==",
+      "version": "7.0.0-rc.2",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.0.0-rc.2.tgz",
+      "integrity": "sha512-nL5PV6/VjuBreNsaJm00RzdIuC8ITK1O++WFwlZLOen5CPNSFmpOqP84J088hGk3tU9Iw5x4ETEzYHrf/5/72g==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.56"
-      },
-      "dependencies": {
-        "@babel/helper-plugin-utils": {
-          "version": "7.0.0-beta.56",
-          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0-beta.56.tgz",
-          "integrity": "sha512-6IlFMU13X7gwnnMldDHwfc7IqngqCH/KfiU7I+GdNoZPnddmjghc87E/zKHaJpWdX1VvXCCelp2EnKq0rgBQ8w==",
-          "dev": true
-        }
+        "@babel/helper-plugin-utils": "7.0.0-rc.2"
       }
     },
     "@babel/plugin-transform-unicode-regex": {
-      "version": "7.0.0-beta.56",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.0.0-beta.56.tgz",
-      "integrity": "sha512-31lEbd5voBJR8ufUuOaRu/r2dxj53S/fs+VNgPqCqvOw7Ql8AuuinYvJjxbzpZ5GqAWLPX1MKBgJ+gsjomXb6g==",
+      "version": "7.0.0-rc.2",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.0.0-rc.2.tgz",
+      "integrity": "sha512-C+28QnIFb8jmw1NegaOtVxnZpBz748h/zsxmAq+uP9J8yGXLA7LtKrFLi00Ky+554BCnqf8Ftp5Fd3NaYpPOOQ==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.56",
-        "@babel/helper-regex": "7.0.0-beta.56",
+        "@babel/helper-plugin-utils": "7.0.0-rc.2",
+        "@babel/helper-regex": "7.0.0-rc.2",
         "regexpu-core": "^4.1.3"
-      },
-      "dependencies": {
-        "@babel/helper-plugin-utils": {
-          "version": "7.0.0-beta.56",
-          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0-beta.56.tgz",
-          "integrity": "sha512-6IlFMU13X7gwnnMldDHwfc7IqngqCH/KfiU7I+GdNoZPnddmjghc87E/zKHaJpWdX1VvXCCelp2EnKq0rgBQ8w==",
-          "dev": true
-        }
       }
     },
     "@babel/polyfill": {
@@ -2342,116 +775,71 @@
       }
     },
     "@babel/preset-env": {
-      "version": "7.0.0-beta.56",
-      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.0.0-beta.56.tgz",
-      "integrity": "sha512-kFjCCUuMr0Y0N1je1QtOd37WXCU3cEnAqjm4GRlbgWlBPcj7A7ZQ40jMfrPeqVUJBbFiqi/UbOK5iLP/K8wdsA==",
+      "version": "7.0.0-rc.2",
+      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.0.0-rc.2.tgz",
+      "integrity": "sha512-R9Jwm67dPSjlIJmI85hhRsI+JvHCBQLmDwkpo8URCGZ9YxoMgB2Xz3w0fN8x81adIKWZ0/JZaB1m4KWy56qg1g==",
       "dev": true,
       "requires": {
-        "@babel/helper-module-imports": "7.0.0-beta.56",
-        "@babel/helper-plugin-utils": "7.0.0-beta.56",
-        "@babel/plugin-proposal-async-generator-functions": "7.0.0-beta.56",
-        "@babel/plugin-proposal-object-rest-spread": "7.0.0-beta.56",
-        "@babel/plugin-proposal-optional-catch-binding": "7.0.0-beta.56",
-        "@babel/plugin-proposal-unicode-property-regex": "7.0.0-beta.56",
-        "@babel/plugin-syntax-async-generators": "7.0.0-beta.56",
-        "@babel/plugin-syntax-object-rest-spread": "7.0.0-beta.56",
-        "@babel/plugin-syntax-optional-catch-binding": "7.0.0-beta.56",
-        "@babel/plugin-transform-arrow-functions": "7.0.0-beta.56",
-        "@babel/plugin-transform-async-to-generator": "7.0.0-beta.56",
-        "@babel/plugin-transform-block-scoped-functions": "7.0.0-beta.56",
-        "@babel/plugin-transform-block-scoping": "7.0.0-beta.56",
-        "@babel/plugin-transform-classes": "7.0.0-beta.56",
-        "@babel/plugin-transform-computed-properties": "7.0.0-beta.56",
-        "@babel/plugin-transform-destructuring": "7.0.0-beta.56",
-        "@babel/plugin-transform-dotall-regex": "7.0.0-beta.56",
-        "@babel/plugin-transform-duplicate-keys": "7.0.0-beta.56",
-        "@babel/plugin-transform-exponentiation-operator": "7.0.0-beta.56",
-        "@babel/plugin-transform-for-of": "7.0.0-beta.56",
-        "@babel/plugin-transform-function-name": "7.0.0-beta.56",
-        "@babel/plugin-transform-literals": "7.0.0-beta.56",
-        "@babel/plugin-transform-modules-amd": "7.0.0-beta.56",
-        "@babel/plugin-transform-modules-commonjs": "7.0.0-beta.56",
-        "@babel/plugin-transform-modules-systemjs": "7.0.0-beta.56",
-        "@babel/plugin-transform-modules-umd": "7.0.0-beta.56",
-        "@babel/plugin-transform-new-target": "7.0.0-beta.56",
-        "@babel/plugin-transform-object-super": "7.0.0-beta.56",
-        "@babel/plugin-transform-parameters": "7.0.0-beta.56",
-        "@babel/plugin-transform-regenerator": "7.0.0-beta.56",
-        "@babel/plugin-transform-shorthand-properties": "7.0.0-beta.56",
-        "@babel/plugin-transform-spread": "7.0.0-beta.56",
-        "@babel/plugin-transform-sticky-regex": "7.0.0-beta.56",
-        "@babel/plugin-transform-template-literals": "7.0.0-beta.56",
-        "@babel/plugin-transform-typeof-symbol": "7.0.0-beta.56",
-        "@babel/plugin-transform-unicode-regex": "7.0.0-beta.56",
+        "@babel/helper-module-imports": "7.0.0-rc.2",
+        "@babel/helper-plugin-utils": "7.0.0-rc.2",
+        "@babel/plugin-proposal-async-generator-functions": "7.0.0-rc.2",
+        "@babel/plugin-proposal-json-strings": "7.0.0-rc.2",
+        "@babel/plugin-proposal-object-rest-spread": "7.0.0-rc.2",
+        "@babel/plugin-proposal-optional-catch-binding": "7.0.0-rc.2",
+        "@babel/plugin-proposal-unicode-property-regex": "7.0.0-rc.2",
+        "@babel/plugin-syntax-async-generators": "7.0.0-rc.2",
+        "@babel/plugin-syntax-object-rest-spread": "7.0.0-rc.2",
+        "@babel/plugin-syntax-optional-catch-binding": "7.0.0-rc.2",
+        "@babel/plugin-transform-arrow-functions": "7.0.0-rc.2",
+        "@babel/plugin-transform-async-to-generator": "7.0.0-rc.2",
+        "@babel/plugin-transform-block-scoped-functions": "7.0.0-rc.2",
+        "@babel/plugin-transform-block-scoping": "7.0.0-rc.2",
+        "@babel/plugin-transform-classes": "7.0.0-rc.2",
+        "@babel/plugin-transform-computed-properties": "7.0.0-rc.2",
+        "@babel/plugin-transform-destructuring": "7.0.0-rc.2",
+        "@babel/plugin-transform-dotall-regex": "7.0.0-rc.2",
+        "@babel/plugin-transform-duplicate-keys": "7.0.0-rc.2",
+        "@babel/plugin-transform-exponentiation-operator": "7.0.0-rc.2",
+        "@babel/plugin-transform-for-of": "7.0.0-rc.2",
+        "@babel/plugin-transform-function-name": "7.0.0-rc.2",
+        "@babel/plugin-transform-literals": "7.0.0-rc.2",
+        "@babel/plugin-transform-modules-amd": "7.0.0-rc.2",
+        "@babel/plugin-transform-modules-commonjs": "7.0.0-rc.2",
+        "@babel/plugin-transform-modules-systemjs": "7.0.0-rc.2",
+        "@babel/plugin-transform-modules-umd": "7.0.0-rc.2",
+        "@babel/plugin-transform-new-target": "7.0.0-rc.2",
+        "@babel/plugin-transform-object-super": "7.0.0-rc.2",
+        "@babel/plugin-transform-parameters": "7.0.0-rc.2",
+        "@babel/plugin-transform-regenerator": "7.0.0-rc.2",
+        "@babel/plugin-transform-shorthand-properties": "7.0.0-rc.2",
+        "@babel/plugin-transform-spread": "7.0.0-rc.2",
+        "@babel/plugin-transform-sticky-regex": "7.0.0-rc.2",
+        "@babel/plugin-transform-template-literals": "7.0.0-rc.2",
+        "@babel/plugin-transform-typeof-symbol": "7.0.0-rc.2",
+        "@babel/plugin-transform-unicode-regex": "7.0.0-rc.2",
         "browserslist": "^3.0.0",
         "invariant": "^2.2.2",
         "js-levenshtein": "^1.1.3",
         "semver": "^5.3.0"
-      },
-      "dependencies": {
-        "@babel/helper-module-imports": {
-          "version": "7.0.0-beta.56",
-          "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.0.0-beta.56.tgz",
-          "integrity": "sha512-iVWFscU+yIu6DIo5IWkMgVXd74/d3z/ZomwF/QJNGFwFP/lNA282rpjsky56fSxS7oT7wAlXoYoHVCOOaL7tbg==",
-          "dev": true,
-          "requires": {
-            "@babel/types": "7.0.0-beta.56",
-            "lodash": "^4.17.10"
-          }
-        },
-        "@babel/helper-plugin-utils": {
-          "version": "7.0.0-beta.56",
-          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0-beta.56.tgz",
-          "integrity": "sha512-6IlFMU13X7gwnnMldDHwfc7IqngqCH/KfiU7I+GdNoZPnddmjghc87E/zKHaJpWdX1VvXCCelp2EnKq0rgBQ8w==",
-          "dev": true
-        },
-        "@babel/types": {
-          "version": "7.0.0-beta.56",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.56.tgz",
-          "integrity": "sha512-fRIBeHtKxAD3D1E7hYSpG4MnLt0AfzHHs5gfVclOB0NlfLu3qiWU/IqdbK2ixTK61424iEkV1P/VAzndx6ungA==",
-          "dev": true,
-          "requires": {
-            "esutils": "^2.0.2",
-            "lodash": "^4.17.10",
-            "to-fast-properties": "^2.0.0"
-          }
-        }
-      }
-    },
-    "@babel/preset-flow": {
-      "version": "7.0.0-beta.52",
-      "resolved": "https://registry.npmjs.org/@babel/preset-flow/-/preset-flow-7.0.0-beta.52.tgz",
-      "integrity": "sha1-2ioPV23754uSCirCxHgxqJxSYAQ=",
-      "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.52",
-        "@babel/plugin-transform-flow-strip-types": "7.0.0-beta.52"
       }
     },
     "@babel/preset-react": {
-      "version": "7.0.0-beta.56",
-      "resolved": "https://registry.npmjs.org/@babel/preset-react/-/preset-react-7.0.0-beta.56.tgz",
-      "integrity": "sha512-xWj8x03hp8ZDghjlA81Yodx8EF6yjOgqFH5HVJmUAj7jjF1PrsNNCjACcz7mOBtKsOsv95jtKz/Rc3CcLeHqgw==",
+      "version": "7.0.0-rc.2",
+      "resolved": "https://registry.npmjs.org/@babel/preset-react/-/preset-react-7.0.0-rc.2.tgz",
+      "integrity": "sha512-FjBjiW6l6p5mE0oRaWTzAWnFYGGVi7MwtXX5FYoRBkzIsXq5O/uhwbc+05XIlXbVZlZ/WZbUzCDSZloeQ1xWPA==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.56",
-        "@babel/plugin-transform-react-display-name": "7.0.0-beta.56",
-        "@babel/plugin-transform-react-jsx": "7.0.0-beta.56",
-        "@babel/plugin-transform-react-jsx-self": "7.0.0-beta.56",
-        "@babel/plugin-transform-react-jsx-source": "7.0.0-beta.56"
-      },
-      "dependencies": {
-        "@babel/helper-plugin-utils": {
-          "version": "7.0.0-beta.56",
-          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0-beta.56.tgz",
-          "integrity": "sha512-6IlFMU13X7gwnnMldDHwfc7IqngqCH/KfiU7I+GdNoZPnddmjghc87E/zKHaJpWdX1VvXCCelp2EnKq0rgBQ8w==",
-          "dev": true
-        }
+        "@babel/helper-plugin-utils": "7.0.0-rc.2",
+        "@babel/plugin-transform-react-display-name": "7.0.0-rc.2",
+        "@babel/plugin-transform-react-jsx": "7.0.0-rc.2",
+        "@babel/plugin-transform-react-jsx-self": "7.0.0-rc.2",
+        "@babel/plugin-transform-react-jsx-source": "7.0.0-rc.2"
       }
     },
     "@babel/runtime": {
-      "version": "7.0.0-beta.56",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.0.0-beta.56.tgz",
-      "integrity": "sha512-vP9XV2VP013UEyZdU9eWClCsm6rQPUYHVNCfmpcv5uKviW7mKmUZq71Y5cr5dYsFKfnGDxSo8h6plUGR60lwHg==",
+      "version": "7.0.0-rc.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.0.0-rc.2.tgz",
+      "integrity": "sha512-QugZtHk0uVHqHmgwNn2f2uOtTwXWPBBZVSH2EFRm9iw1fFmi5fm46ye6NSVSiXT9Ymejh7fKIw3riCv23SNtSQ==",
       "dev": true,
       "requires": {
         "regenerator-runtime": "^0.12.0"
@@ -2466,40 +854,41 @@
       }
     },
     "@babel/template": {
-      "version": "7.0.0-beta.52",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.0.0-beta.52.tgz",
-      "integrity": "sha1-ROGPrDglH1f5JRHWdI8JWrAvmW4=",
+      "version": "7.0.0-rc.2",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.0.0-rc.2.tgz",
+      "integrity": "sha512-CryGZ01Nko2/g8gkYiiPc7x9ZinrX59/BTWMZV1sDj5cAeia64vhyNnXTcNeim885IdGOdYyia1PNBWKnFxuSw==",
+      "dev": true,
       "requires": {
-        "@babel/code-frame": "7.0.0-beta.52",
-        "@babel/parser": "7.0.0-beta.52",
-        "@babel/types": "7.0.0-beta.52",
-        "lodash": "^4.17.5"
+        "@babel/code-frame": "7.0.0-rc.2",
+        "@babel/parser": "7.0.0-rc.2",
+        "@babel/types": "7.0.0-rc.2"
       }
     },
     "@babel/traverse": {
-      "version": "7.0.0-beta.52",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.0.0-beta.52.tgz",
-      "integrity": "sha1-m4uplPcmTZhHhYrS/uzCc4xeLvM=",
+      "version": "7.0.0-rc.2",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.0.0-rc.2.tgz",
+      "integrity": "sha512-x8y9E+KZHs3Xmy5uiYmr1TtDhOBAZnL9vUtLIt95Pw3jovkY9q2NIwgLzfSlzOU83sQvzAooZWuJ65JERwxx+Q==",
+      "dev": true,
       "requires": {
-        "@babel/code-frame": "7.0.0-beta.52",
-        "@babel/generator": "7.0.0-beta.52",
-        "@babel/helper-function-name": "7.0.0-beta.52",
-        "@babel/helper-split-export-declaration": "7.0.0-beta.52",
-        "@babel/parser": "7.0.0-beta.52",
-        "@babel/types": "7.0.0-beta.52",
+        "@babel/code-frame": "7.0.0-rc.2",
+        "@babel/generator": "7.0.0-rc.2",
+        "@babel/helper-function-name": "7.0.0-rc.2",
+        "@babel/helper-split-export-declaration": "7.0.0-rc.2",
+        "@babel/parser": "7.0.0-rc.2",
+        "@babel/types": "7.0.0-rc.2",
         "debug": "^3.1.0",
         "globals": "^11.1.0",
-        "invariant": "^2.2.0",
-        "lodash": "^4.17.5"
+        "lodash": "^4.17.10"
       }
     },
     "@babel/types": {
-      "version": "7.0.0-beta.52",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.52.tgz",
-      "integrity": "sha1-o+ViCxU0slOlCrzyIitSDiOxbaI=",
+      "version": "7.0.0-rc.2",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-rc.2.tgz",
+      "integrity": "sha512-I2SMGD8bUX7sysOwGM8TcwCoaHiOx2YWZmT9h5oAncsPQ9Wy068yJneCF4vkOGTCzPFIETPDR5i3EIEm5QgMFg==",
+      "dev": true,
       "requires": {
         "esutils": "^2.0.2",
-        "lodash": "^4.17.5",
+        "lodash": "^4.17.10",
         "to-fast-properties": "^2.0.0"
       }
     },
@@ -3574,11 +1963,6 @@
       "resolved": "https://registry.npmjs.org/@types/graphql/-/graphql-0.12.6.tgz",
       "integrity": "sha512-wXAVyLfkG1UMkKOdMijVWFky39+OD/41KftzqfX1Oejd0Gm6dOIKjCihSVECg6X7PHjftxXmfOKA/d1H79ZfvQ=="
     },
-    "@types/history": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/@types/history/-/history-4.7.0.tgz",
-      "integrity": "sha512-1A/RUAX4VtmGzNTGLSfmiPxQ3XwUSe/1YN4lW9GRa+j307oFK6MPjhlvw6jEHDodUBIvSvrA7/iHDchr5LS+0Q=="
-    },
     "@types/minimatch": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
@@ -3590,35 +1974,33 @@
       "integrity": "sha1-fyrX7FX5FEgvybHsS7GuYCjUYGY="
     },
     "@types/node": {
-      "version": "7.0.68",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-7.0.68.tgz",
-      "integrity": "sha512-ym3LNHwJQU0XDyPrTK6NHJTH5YmGKKe0k56in6pg+Wx4HD8fiKrt8xute6/unHvHujCfzmOQTGz1NoEKgFF5Mw=="
+      "version": "10.7.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.7.1.tgz",
+      "integrity": "sha512-EGoI4ylB/lPOaqXqtzAyL8HcgOuCtH2hkEaLmkueOYufsTFWBn4VCvlCDC2HW8Q+9iF+QVC3sxjDKQYjHQeZ9w=="
     },
-    "@types/react": {
-      "version": "16.4.7",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.4.7.tgz",
-      "integrity": "sha512-tHpSs7HMyjnpyfzka1G0pYh7rBNdpwGgcIDT4vfV6jUaR69yOHo/vNH2H+d9iYHo9xnX4qDe7UalPe9HiGRkLw==",
+    "@types/prop-types": {
+      "version": "15.5.5",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.5.5.tgz",
+      "integrity": "sha512-mOrlCEdwX3seT3n0AXNt4KNPAZZxcsABUHwBgFXOt+nvFUXkxCAO6UBJHPrDxWEa2KDMil86355fjo8jbZ+K0Q==",
       "requires": {
-        "csstype": "^2.2.0"
-      }
-    },
-    "@types/react-router": {
-      "version": "4.0.30",
-      "resolved": "https://registry.npmjs.org/@types/react-router/-/react-router-4.0.30.tgz",
-      "integrity": "sha512-zWt5RpWy7x7semeBIHqLZ31A1Tle0jb3R/KD2wguZqO43DjP4n8kYsH7UIpve6I4hzlSObnoIieDcp5qfyKwaQ==",
-      "requires": {
-        "@types/history": "*",
         "@types/react": "*"
       }
     },
-    "@types/react-router-dom": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@types/react-router-dom/-/react-router-dom-4.3.0.tgz",
-      "integrity": "sha512-vaq+nVUGyMnIhAl+svKHmfqhCoCNe5lf1UWmvVcsBlAcX0kznF25711DNFQ7B8/QZ+ZF1zzGq1dIi9bzxIu85w==",
+    "@types/reach__router": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@types/reach__router/-/reach__router-1.0.0.tgz",
+      "integrity": "sha512-a00BZkqeZQfwGOQAku5snJR72IWdQaT5Cy7pctQ95Mf03GGdmwRkILr+NkhHtqmSHUGyMajv8mM2uWlaEe+XKQ==",
       "requires": {
-        "@types/history": "*",
-        "@types/react": "*",
-        "@types/react-router": "*"
+        "@types/react": "*"
+      }
+    },
+    "@types/react": {
+      "version": "16.4.11",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.4.11.tgz",
+      "integrity": "sha512-1DQnmwO8u8N3ucvRX2ZLDEjQ2VctkAvL/rpbm2ev4uaZA0z4ysU+I0tk+K8ZLblC6p7MCgFyF+cQlSNIPUHzeQ==",
+      "requires": {
+        "@types/prop-types": "*",
+        "csstype": "^2.2.0"
       }
     },
     "@types/tmp": {
@@ -3800,65 +2182,6 @@
         "long": "^3.2.0"
       }
     },
-    "@webpack-contrib/schema-utils": {
-      "version": "1.0.0-beta.0",
-      "resolved": "https://registry.npmjs.org/@webpack-contrib/schema-utils/-/schema-utils-1.0.0-beta.0.tgz",
-      "integrity": "sha512-LonryJP+FxQQHsjGBi6W786TQB1Oym+agTpY0c+Kj8alnIw+DLUJb6SI8Y1GHGhLCH1yPRrucjObUmxNICQ1pg==",
-      "requires": {
-        "ajv": "^6.1.0",
-        "ajv-keywords": "^3.1.0",
-        "chalk": "^2.3.2",
-        "strip-ansi": "^4.0.0",
-        "text-table": "^0.2.0",
-        "webpack-log": "^1.1.2"
-      },
-      "dependencies": {
-        "ajv": {
-          "version": "6.5.2",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.5.2.tgz",
-          "integrity": "sha512-hOs7GfvI6tUI1LfZddH82ky6mOMyTuY0mk7kE2pWpmhhUSkumzaTO5vbVwij39MdwPQWCV4Zv57Eo06NtL/GVA==",
-          "requires": {
-            "fast-deep-equal": "^2.0.1",
-            "fast-json-stable-stringify": "^2.0.0",
-            "json-schema-traverse": "^0.4.1",
-            "uri-js": "^4.2.1"
-          }
-        },
-        "ajv-keywords": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.2.0.tgz",
-          "integrity": "sha1-6GuBnGAs+IIa1jdBNpjx3sAhhHo="
-        },
-        "ansi-regex": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
-        },
-        "fast-deep-equal": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
-          "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
-        },
-        "json-schema-traverse": {
-          "version": "0.4.1",
-          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-          "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
-        },
-        "strip-ansi": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-          "requires": {
-            "ansi-regex": "^3.0.0"
-          }
-        }
-      }
-    },
-    "@zeit/schemas": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@zeit/schemas/-/schemas-1.7.0.tgz",
-      "integrity": "sha512-Ma2HHFqwZZ5WOEMcd/8RJj70O9jy2esTvu9oaYLJSkenELKrv6vgkGeM5jB8xLRTYocpcnd2rCfpyKyhBqVphQ=="
-    },
     "abab": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.0.tgz",
@@ -3961,6 +2284,11 @@
         "json-schema-traverse": "^0.3.0"
       }
     },
+    "ajv-errors": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ajv-errors/-/ajv-errors-1.0.0.tgz",
+      "integrity": "sha1-7PAh+hCP0X37Xms4Py3SM+Mf/Fk="
+    },
     "ajv-keywords": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-2.1.1.tgz",
@@ -4050,9 +2378,9 @@
       }
     },
     "apollo-utilities": {
-      "version": "1.0.17",
-      "resolved": "https://registry.npmjs.org/apollo-utilities/-/apollo-utilities-1.0.17.tgz",
-      "integrity": "sha512-Mm8pS48QVV/CUbcUFN5TmbkdjIJtYw99qVqbBHnIwL8x0H2RW0NpzASpC+5+qSxD1sKNLUl9pA6F5Et/0bbaVg==",
+      "version": "1.0.19",
+      "resolved": "https://registry.npmjs.org/apollo-utilities/-/apollo-utilities-1.0.19.tgz",
+      "integrity": "sha512-pyVxizjIevHFfKhtc9FLEsGHmqiK0kHx1aBdJRUXDt+X+yjoVa/fVeCEo9t0NddGximemxxrQnq6lSkbIQvDlA==",
       "requires": {
         "fast-json-stable-stringify": "^2.0.0"
       }
@@ -4077,11 +2405,6 @@
       "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
       "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw=="
     },
-    "arch": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/arch/-/arch-2.1.1.tgz",
-      "integrity": "sha512-BLM56aPo9vLLFVa8+/+pJLnrZ7QGGTVHWsCwieAWT9o9K8UeGaQbzZbGoabWLOo2ksBCztoXdqBZBplqLDDCSg=="
-    },
     "are-we-there-yet": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
@@ -4091,11 +2414,6 @@
         "delegates": "^1.0.0",
         "readable-stream": "^2.0.6"
       }
-    },
-    "arg": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/arg/-/arg-2.0.0.tgz",
-      "integrity": "sha512-XxNTUzKnz1ctK3ZIcI2XUPlD96wbHP2nGqkPKpvk/HNRlPveYrXIVSTk9m3LcqOgDPg3B1nMvdV/K8wZd7PG4w=="
     },
     "argparse": {
       "version": "1.0.10",
@@ -4296,6 +2614,7 @@
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
       "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
+      "dev": true,
       "requires": {
         "lodash": "^4.17.10"
       }
@@ -4339,9 +2658,9 @@
       "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
     },
     "aws4": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.7.0.tgz",
-      "integrity": "sha512-32NDda82rhwD9/JBCCkB+MRYDp0oSvlo2IL6rQWA10PQi7tDUM3eqMSltXmY+Oyl/7N3P3qNtAlv7X0d9bI28w=="
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
+      "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ=="
     },
     "axobject-query": {
       "version": "2.0.1",
@@ -4892,7 +3211,6 @@
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-2.4.0.tgz",
       "integrity": "sha512-flIBfrqAdHWn+4l2cS/4jZEyl+m5EaBHVzTb0aOF+eu/zR7E41/MoCFHPhDNL8Wzq1nyelnXeT+vcL2byFLSZw==",
-      "dev": true,
       "requires": {
         "cosmiconfig": "^5.0.5"
       }
@@ -5004,9 +3322,9 @@
       }
     },
     "babel-plugin-remove-graphql-queries": {
-      "version": "2.0.2-beta.8",
-      "resolved": "https://registry.npmjs.org/babel-plugin-remove-graphql-queries/-/babel-plugin-remove-graphql-queries-2.0.2-beta.8.tgz",
-      "integrity": "sha1-3pCt/XUjwvfcypeuvaciwLCWup8="
+      "version": "2.0.2-rc.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-remove-graphql-queries/-/babel-plugin-remove-graphql-queries-2.0.2-rc.0.tgz",
+      "integrity": "sha512-0M28sv7smtfYaOaE5NZHnNkCEdfkbbEa030J7F4UA+ZMFa9bxdU+ToMoNrGvJ0LL6wU/wqj7fLP7vbEumx/H5w=="
     },
     "babel-plugin-syntax-async-functions": {
       "version": "6.13.0",
@@ -6491,13 +4809,33 @@
       },
       "dependencies": {
         "browserslist": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.0.1.tgz",
-          "integrity": "sha512-QqiiIWchEIkney3wY53/huI7ZErouNAdvOkjorUALAwRcu3tEwOV3Sh6He0DnP38mz1JjBpCBb50jQBmaYuHPw==",
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.0.2.tgz",
+          "integrity": "sha512-lpujC4zv1trcKUUwfD4pFVNga4YSpB3sLB+/I+A8gvGQxno1c0dMB2aCQy0FE5oUNIDjD9puFiFF0zeS6Ji48w==",
           "requires": {
-            "caniuse-lite": "^1.0.30000865",
-            "electron-to-chromium": "^1.3.52",
-            "node-releases": "^1.0.0-alpha.10"
+            "caniuse-lite": "^1.0.30000876",
+            "electron-to-chromium": "^1.3.57",
+            "node-releases": "^1.0.0-alpha.11"
+          },
+          "dependencies": {
+            "caniuse-lite": {
+              "version": "1.0.30000878",
+              "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000878.tgz",
+              "integrity": "sha512-/dCGTdLCnjVJno1mFRn7Y6eit3AYaeFzSrMQHCoK0LEQaWl5snuLex1Ky4b8/Qu2ig5NgTX4cJx65hH9546puA=="
+            }
+          }
+        },
+        "electron-to-chromium": {
+          "version": "1.3.59",
+          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.59.tgz",
+          "integrity": "sha512-PbJGGpDSNn3fyUN1eQESAmnMT+a1QAO4NEZgikDuGOn7tbAuMHF87jNna+NoVsMBfEEYzfpn/ay88HgDCJUbQA=="
+        },
+        "node-releases": {
+          "version": "1.0.0-alpha.11",
+          "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.0.0-alpha.11.tgz",
+          "integrity": "sha512-CaViu+2FqTNYOYNihXa5uPS/zry92I3vPU4nCB6JB3OeZ2UGtOpF5gRwuN4+m3hbEcL47bOXyun1jX2iC+3uEQ==",
+          "requires": {
+            "semver": "^5.3.0"
           }
         }
       }
@@ -6577,18 +4915,6 @@
         "parse5": "^3.0.1"
       },
       "dependencies": {
-        "css-select": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/css-select/-/css-select-1.2.0.tgz",
-          "integrity": "sha1-KzoRBTnFNV8c2NMUYj6HCxIeyFg=",
-          "dev": true,
-          "requires": {
-            "boolbase": "~1.0.0",
-            "css-what": "2.1",
-            "domutils": "1.5.1",
-            "nth-check": "~1.0.1"
-          }
-        },
         "domhandler": {
           "version": "2.4.2",
           "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.4.2.tgz",
@@ -6648,9 +4974,9 @@
       }
     },
     "ci-info": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.1.3.tgz",
-      "integrity": "sha512-SK/846h/Rcy8q9Z9CAwGBLfCJ6EkjJWdpelWDufQpqVDYq2Wnnv8zlSO6AMQap02jvhVruKKpEtQOufo3pFhLg=="
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.4.0.tgz",
+      "integrity": "sha512-Oqmw2pVfCl8sCL+1QgMywPfdxPJPkC51y4usw0iiE2S9qnEOAqXy8bwl1CpMpnoU39g4iKJTz6QZj+28FvOnjQ=="
     },
     "cipher-base": {
       "version": "1.0.4",
@@ -6719,15 +5045,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
       "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk="
-    },
-    "clipboardy": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/clipboardy/-/clipboardy-1.2.3.tgz",
-      "integrity": "sha512-2WNImOvCRe6r63Gk9pShfkwXsVtKCroMAevIbiae021mS850UkWPbevxsBz3tnvjZIEGvlwaqCPsw+4ulzNgJA==",
-      "requires": {
-        "arch": "^2.1.0",
-        "execa": "^0.8.0"
-      }
     },
     "cliui": {
       "version": "4.1.0",
@@ -6813,9 +5130,10 @@
       }
     },
     "colors": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
-      "integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM="
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-0.5.1.tgz",
+      "integrity": "sha1-fQAj6usVTo7p/Oddy5I9DtFmd3Q=",
+      "dev": true
     },
     "combined-stream": {
       "version": "1.0.6",
@@ -6846,9 +5164,9 @@
       "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs="
     },
     "compare-versions": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-3.3.0.tgz",
-      "integrity": "sha512-MAAAIOdi2s4Gl6rZ76PNcUa9IOYB+5ICdT41o5uMRf09aEu/F9RK+qhe8RjXNPwcTjGV7KU7h2P/fljThFVqyQ==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-3.3.1.tgz",
+      "integrity": "sha512-GkIcfJ9sDt4+gS+RWH3X+kR7ezuKdu3fg2oA9nRA8HZoqZwAKv3ml3TyfB9OyV2iFXxCw7q5XfV6SyPbSCT2pw==",
       "dev": true
     },
     "component-bind": {
@@ -7129,18 +5447,23 @@
       }
     },
     "cross-fetch": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-2.0.0.tgz",
-      "integrity": "sha512-gnx0GnDyW73iDq6DpqceL8i4GGn55PPKDzNwZkopJ3mKPcfJ0BUIXBsnYfJBVw+jFDB+hzIp2ELNRdqoxN6M3w==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-2.2.2.tgz",
+      "integrity": "sha1-pH/09/xxLauo9qaVoRyUhEDUVyM=",
       "requires": {
-        "node-fetch": "2.0.0",
-        "whatwg-fetch": "2.0.3"
+        "node-fetch": "2.1.2",
+        "whatwg-fetch": "2.0.4"
       },
       "dependencies": {
         "node-fetch": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.0.0.tgz",
-          "integrity": "sha1-mCu6Q+zU8pIqKcwYamu7C7c/y6Y="
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.1.2.tgz",
+          "integrity": "sha1-q4hOjn5X44qUR1POxwb3iNF2i7U="
+        },
+        "whatwg-fetch": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz",
+          "integrity": "sha512-dcQ1GWpOD/eEQ97k66aiEVpNnapVj90/+R+SXTPYGHpYBBypfKJEQjLrvMZ7YXbKm21gXd4NcuxUTjiv1YtLng=="
         }
       }
     },
@@ -7226,14 +5549,15 @@
       }
     },
     "css-select": {
-      "version": "1.3.0-rc0",
-      "resolved": "https://registry.npmjs.org/css-select/-/css-select-1.3.0-rc0.tgz",
-      "integrity": "sha1-b5MZaqrnN2ZuoQNqjLFKj8t6kjE=",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-1.2.0.tgz",
+      "integrity": "sha1-KzoRBTnFNV8c2NMUYj6HCxIeyFg=",
+      "dev": true,
       "requires": {
-        "boolbase": "^1.0.0",
+        "boolbase": "~1.0.0",
         "css-what": "2.1",
         "domutils": "1.5.1",
-        "nth-check": "^1.0.1"
+        "nth-check": "~1.0.1"
       }
     },
     "css-select-base-adapter": {
@@ -7407,9 +5731,9 @@
       "dev": true
     },
     "cssstyle": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-1.0.0.tgz",
-      "integrity": "sha512-Bpuh47j2mRMY60X90mXaJAEtJwxvA2roZzbgwAXYhMbmwmakdRr4Cq9L5SkleKJNLOKqHIa2YWyOXDX3VgggSQ==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-1.1.1.tgz",
+      "integrity": "sha512-364AI1l/M5TYcFH83JnOH/pSqgaNnKmYgKrm0didZMGKWjQB60dymwWy1rKUgL3J1ffdq9xVi2yGLHdSjjSNog==",
       "dev": true,
       "requires": {
         "cssom": "0.3.x"
@@ -7455,21 +5779,26 @@
       }
     },
     "data-urls": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-1.0.0.tgz",
-      "integrity": "sha512-ai40PPQR0Fn1lD2PPie79CibnlMN2AYiDhwFX/rZHVsxbs5kNJSjegqXIprhouGXlRdEnfybva7kqRGnB6mypA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-1.0.1.tgz",
+      "integrity": "sha512-0HdcMZzK6ubMUnsMmQmG0AcLQPvbvb47R0+7CCZQCYgcd8OUWG91CG7sM6GoXgjz+WLl4ArFzHtBMy/QqSF4eg==",
       "dev": true,
       "requires": {
-        "abab": "^1.0.4",
-        "whatwg-mimetype": "^2.0.0",
-        "whatwg-url": "^6.4.0"
+        "abab": "^2.0.0",
+        "whatwg-mimetype": "^2.1.0",
+        "whatwg-url": "^7.0.0"
       },
       "dependencies": {
-        "abab": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/abab/-/abab-1.0.4.tgz",
-          "integrity": "sha1-X6rZwsB/YN12dw9xzwJbYqY8/U4=",
-          "dev": true
+        "whatwg-url": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.0.0.tgz",
+          "integrity": "sha512-37GeVSIJ3kn1JgKyjiYNmSLP1yzbpb29jdmwBSgkD9h40/hyrR/OifpVUndji3tmwGgD8qpw7iQu3RSbCrBpsQ==",
+          "dev": true,
+          "requires": {
+            "lodash.sortby": "^4.7.0",
+            "tr46": "^1.0.1",
+            "webidl-conversions": "^4.0.2"
+          }
         }
       }
     },
@@ -7677,6 +6006,11 @@
         "tslib": "^1.6.0"
       },
       "dependencies": {
+        "@types/node": {
+          "version": "7.0.69",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-7.0.69.tgz",
+          "integrity": "sha512-S5NC8HV6HnRipg8nC0j30TPl7ktXjRTKqgyINLNe8K/64UJUI8Lq0sRopXC0hProsV2F5ibj8IqPkl1xpGggrw=="
+        },
         "debug": {
           "version": "2.6.9",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -8047,21 +6381,22 @@
       "integrity": "sha512-rXbzXWvnQxy+TcqZlARbWVQwgGVVouVJgFZhLVN5htjLxl1thstrP2ZGi0pXC309AbK7gVOPU+ulz/tmpCI7iw=="
     },
     "enzyme": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/enzyme/-/enzyme-3.3.0.tgz",
-      "integrity": "sha512-l8csyPyLmtxskTz6pX9W8eDOyH1ckEtDttXk/vlFWCjv00SkjTjtoUrogqp4yEvMyneU9dUJoOLnqFoiHb8IHA==",
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/enzyme/-/enzyme-3.4.4.tgz",
+      "integrity": "sha512-/xkHs9vLDmmZbyvhu0zgBHqK+aAZHyTTXvclLjATqo4SlnpReZ7JqEyrjADAhy2Kha0gKmKq4759E/+VjIExMg==",
       "dev": true,
       "requires": {
+        "array.prototype.flat": "^1.2.1",
         "cheerio": "^1.0.0-rc.2",
-        "function.prototype.name": "^1.0.3",
-        "has": "^1.0.1",
+        "function.prototype.name": "^1.1.0",
+        "has": "^1.0.3",
         "is-boolean-object": "^1.0.0",
-        "is-callable": "^1.1.3",
+        "is-callable": "^1.1.4",
         "is-number-object": "^1.0.3",
         "is-string": "^1.0.4",
         "is-subset": "^0.1.1",
         "lodash": "^4.17.4",
-        "object-inspect": "^1.5.0",
+        "object-inspect": "^1.6.0",
         "object-is": "^1.0.1",
         "object.assign": "^4.1.0",
         "object.entries": "^1.0.4",
@@ -8071,28 +6406,54 @@
       }
     },
     "enzyme-adapter-react-16": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/enzyme-adapter-react-16/-/enzyme-adapter-react-16-1.1.1.tgz",
-      "integrity": "sha512-kC8pAtU2Jk3OJ0EG8Y2813dg9Ol0TXi7UNxHzHiWs30Jo/hj7alc//G1YpKUsPP1oKl9X+Lkx+WlGJpPYA+nvw==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/enzyme-adapter-react-16/-/enzyme-adapter-react-16-1.2.0.tgz",
+      "integrity": "sha512-UgBra+xZFVFbU5Tw7Inw0bPrNJhM2ru4vCoO7preX6sOicXuDbOH927QJx4pk6m6vatd8jnPXTF6/GCjzytJTg==",
       "dev": true,
       "requires": {
-        "enzyme-adapter-utils": "^1.3.0",
-        "lodash": "^4.17.4",
-        "object.assign": "^4.0.4",
+        "enzyme-adapter-utils": "^1.5.0",
+        "function.prototype.name": "^1.1.0",
+        "object.assign": "^4.1.0",
         "object.values": "^1.0.4",
-        "prop-types": "^15.6.0",
+        "prop-types": "^15.6.2",
+        "react-is": "^16.4.2",
         "react-reconciler": "^0.7.0",
         "react-test-renderer": "^16.0.0-0"
+      },
+      "dependencies": {
+        "prop-types": {
+          "version": "15.6.2",
+          "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.2.tgz",
+          "integrity": "sha512-3pboPvLiWD7dkI3qf3KbUe6hKFKa52w+AE0VCqECtf+QHAKgOL37tTaNCnuX1nAAQ4ZhyP+kYVKf8rLmJ/feDQ==",
+          "dev": true,
+          "requires": {
+            "loose-envify": "^1.3.1",
+            "object-assign": "^4.1.1"
+          }
+        }
       }
     },
     "enzyme-adapter-utils": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/enzyme-adapter-utils/-/enzyme-adapter-utils-1.4.0.tgz",
-      "integrity": "sha512-ajvyXQYbmCoKCX/FaraNzBgXDXJBltCd0GdXfKc0DdRPYgCLaZfS6Ts576IFt8aX2GU9ajZv2g5jfcJ+Nttejw==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/enzyme-adapter-utils/-/enzyme-adapter-utils-1.5.0.tgz",
+      "integrity": "sha512-cLUaPYU8GEzAHi/1hiO+ylz4QiQWI8eb9SysAk8Tbul2O918dRf4cfD4s2BjijtwSvhapkOsPW9XRix1EXlJ1Q==",
       "dev": true,
       "requires": {
+        "function.prototype.name": "^1.1.0",
         "object.assign": "^4.1.0",
-        "prop-types": "^15.6.0"
+        "prop-types": "^15.6.2"
+      },
+      "dependencies": {
+        "prop-types": {
+          "version": "15.6.2",
+          "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.2.tgz",
+          "integrity": "sha512-3pboPvLiWD7dkI3qf3KbUe6hKFKa52w+AE0VCqECtf+QHAKgOL37tTaNCnuX1nAAQ4ZhyP+kYVKf8rLmJ/feDQ==",
+          "dev": true,
+          "requires": {
+            "loose-envify": "^1.3.1",
+            "object-assign": "^4.1.1"
+          }
+        }
       }
     },
     "enzyme-to-json": {
@@ -8395,9 +6756,9 @@
       }
     },
     "eslint-plugin-import": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.13.0.tgz",
-      "integrity": "sha512-t6hGKQDMIt9N8R7vLepsYXgDfeuhp6ZJSgtrLEDxonpSubyxUZHjhm6LsAaZX8q6GYVxkbT3kTsV9G5mBCFR6A==",
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.14.0.tgz",
+      "integrity": "sha512-FpuRtniD/AY6sXByma2Wr0TXvXJ4nA/2/04VPlfpmUDPOpOY264x+ILiwnrk/k4RINgDAyFZByxqPUbSQ5YE7g==",
       "requires": {
         "contains-path": "^0.1.0",
         "debug": "^2.6.8",
@@ -8446,10 +6807,11 @@
       }
     },
     "eslint-plugin-react": {
-      "version": "7.10.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.10.0.tgz",
-      "integrity": "sha512-18rzWn4AtbSUxFKKM7aCVcj5LXOhOKdwBino3KKWy4psxfPW0YtIbE8WNRDUdyHFL50BeLb6qFd4vpvNYyp7hw==",
+      "version": "7.11.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.11.1.tgz",
+      "integrity": "sha512-cVVyMadRyW7qsIUh3FHp3u6QHNhOgVrLQYdQEB1bPWBsgbNCHdFAeNMquBMCcZJu59eNthX053L70l7gRt4SCw==",
       "requires": {
+        "array-includes": "^3.0.3",
         "doctrine": "^2.1.0",
         "has": "^1.0.3",
         "jsx-ast-utils": "^2.0.1",
@@ -8682,15 +7044,15 @@
       }
     },
     "expect": {
-      "version": "23.4.0",
-      "resolved": "https://registry.npmjs.org/expect/-/expect-23.4.0.tgz",
-      "integrity": "sha1-baTsyZwUcSU+cogziYOtHrrbYMM=",
+      "version": "23.5.0",
+      "resolved": "https://registry.npmjs.org/expect/-/expect-23.5.0.tgz",
+      "integrity": "sha512-aG083W63tBloy8YgafWuC44EakjYe0Q6Mg35aujBPvyNU38DvLat9BVzOihNP2NZDLaCJiFNe0vejbtO6knnlA==",
       "dev": true,
       "requires": {
         "ansi-styles": "^3.2.0",
-        "jest-diff": "^23.2.0",
+        "jest-diff": "^23.5.0",
         "jest-get-type": "^22.1.0",
-        "jest-matcher-utils": "^23.2.0",
+        "jest-matcher-utils": "^23.5.0",
         "jest-message-util": "^23.4.0",
         "jest-regex-util": "^23.3.0"
       }
@@ -8893,21 +7255,6 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
-    },
-    "fast-url-parser": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/fast-url-parser/-/fast-url-parser-1.1.3.tgz",
-      "integrity": "sha1-9K8+qfNNiicc9YrSs3WfQx8LMY0=",
-      "requires": {
-        "punycode": "^1.3.2"
-      },
-      "dependencies": {
-        "punycode": {
-          "version": "1.4.1",
-          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
-        }
-      }
     },
     "fastparse": {
       "version": "1.1.1",
@@ -9159,9 +7506,9 @@
       }
     },
     "follow-redirects": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.2.tgz",
-      "integrity": "sha512-kssLorP/9acIdpQ2udQVTiCS5LQmdEz9mvdIfDcl1gYX2tPKFADHSyFdvJS040XdFsPzemWtgI3q8mFVCxtX8A==",
+      "version": "1.5.6",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.6.tgz",
+      "integrity": "sha512-xay/eYZGgdpb3rpugZj1HunNaPcqc6fud/RW7LNEQntvKzuRO4DDLL+MnJIbTHh6t3Kda3v2RvhY2doxUddnig==",
       "requires": {
         "debug": "^3.1.0"
       }
@@ -9258,14 +7605,6 @@
       "requires": {
         "inherits": "^2.0.1",
         "readable-stream": "^2.0.0"
-      }
-    },
-    "front-matter": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/front-matter/-/front-matter-2.3.0.tgz",
-      "integrity": "sha1-cgOviWzjV+4E4qpFFp6pHtf2dQQ=",
-      "requires": {
-        "js-yaml": "^3.10.0"
       }
     },
     "fs-exists-cached": {
@@ -9465,7 +7804,8 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -9793,9 +8133,9 @@
       "dev": true
     },
     "gatsby": {
-      "version": "2.0.0-beta.72",
-      "resolved": "https://registry.npmjs.org/gatsby/-/gatsby-2.0.0-beta.72.tgz",
-      "integrity": "sha512-VmaSBx9Zo2ad3cJ4xhk8Q1StOmO8QFJ3os6/Eb+3I0EsXivcESP2uVyB/mugcsQaWHM8OKukZsIUbsf6wexRBw==",
+      "version": "2.0.0-rc.0",
+      "resolved": "https://registry.npmjs.org/gatsby/-/gatsby-2.0.0-rc.0.tgz",
+      "integrity": "sha512-QeEMOsvNehNVjvg/oIy0z8KQA2k56Gq2ePeZIVF5Nxncl0uNTqP7uAs4+oekhMvTE+fgVXXCuGB2ZdsujKlS4w==",
       "requires": {
         "@babel/code-frame": "7.0.0-beta.52",
         "@babel/core": "7.0.0-beta.52",
@@ -9805,24 +8145,24 @@
         "@babel/plugin-transform-runtime": "7.0.0-beta.52",
         "@babel/polyfill": "7.0.0-beta.52",
         "@babel/preset-env": "7.0.0-beta.52",
-        "@babel/preset-flow": "7.0.0-beta.52",
         "@babel/preset-react": "7.0.0-beta.52",
         "@babel/runtime": "7.0.0-beta.52",
         "@babel/traverse": "7.0.0-beta.52",
         "@reach/router": "^1.1.1",
-        "async": "^2.1.2",
         "autoprefixer": "^8.6.5",
         "babel-core": "7.0.0-bridge.0",
         "babel-eslint": "^8.2.2",
         "babel-loader": "8.0.0-beta.4",
         "babel-plugin-add-module-exports": "^0.2.1",
         "babel-plugin-dynamic-import-node": "^1.2.0",
-        "babel-plugin-remove-graphql-queries": "^2.0.2-beta.8",
+        "babel-plugin-macros": "^2.4.0",
+        "babel-plugin-remove-graphql-queries": "^2.0.2-rc.0",
         "better-queue": "^3.8.6",
         "bluebird": "^3.5.0",
         "chalk": "^2.3.2",
         "chokidar": "^2.0.2",
         "common-tags": "^1.4.0",
+        "compression": "^1.7.3",
         "convert-hrtime": "^2.0.0",
         "copyfiles": "^1.2.0",
         "core-js": "^2.5.0",
@@ -9848,20 +8188,18 @@
         "file-loader": "^1.1.11",
         "flat": "^4.0.0",
         "friendly-errors-webpack-plugin": "^1.6.1",
-        "front-matter": "^2.1.0",
         "fs-extra": "^5.0.0",
-        "gatsby-cli": "^2.0.0-beta.7",
-        "gatsby-link": "^2.0.0-beta.7",
-        "gatsby-plugin-page-creator": "^2.0.0-beta.5",
-        "gatsby-react-router-scroll": "^2.0.0-beta.4",
+        "gatsby-cli": "^2.0.0-rc.0",
+        "gatsby-link": "^2.0.0-rc.0",
+        "gatsby-plugin-page-creator": "^2.0.0-rc.0",
+        "gatsby-react-router-scroll": "^2.0.0-rc.0",
         "glob": "^7.1.1",
         "graphql": "^0.13.2",
         "graphql-relay": "^0.5.5",
-        "graphql-skip-limit": "^2.0.0-beta.3",
+        "graphql-skip-limit": "^2.0.0-rc.0",
         "graphql-tools": "^3.0.4",
         "graphql-type-json": "^0.2.1",
         "hash-mod": "^0.0.5",
-        "history": "^4.6.2",
         "invariant": "^2.2.4",
         "is-relative": "^1.0.0",
         "is-relative-url": "^2.0.0",
@@ -9869,11 +8207,8 @@
         "joi": "12.x.x",
         "json-loader": "^0.5.7",
         "json-stringify-safe": "^5.0.1",
-        "json5": "^0.5.0",
         "kebab-hash": "^0.1.2",
         "lodash": "^4.17.4",
-        "lodash-id": "^0.14.0",
-        "lowdb": "0.16.2",
         "md5": "^2.2.1",
         "md5-file": "^3.1.1",
         "mime": "^2.2.0",
@@ -9882,13 +8217,11 @@
         "mkdirp": "^0.5.1",
         "moment": "^2.21.0",
         "name-all-modules-plugin": "^1.0.1",
-        "node-libs-browser": "^2.0.0",
         "normalize-path": "^2.1.1",
         "null-loader": "^0.1.1",
         "opentracing": "^0.14.3",
         "opn": "^5.3.0",
         "parse-filepath": "^1.0.1",
-        "path-exists": "^3.0.0",
         "physical-cpu-count": "^2.0.0",
         "postcss-flexbugs-fixes": "^3.0.0",
         "postcss-loader": "^2.1.3",
@@ -9896,11 +8229,9 @@
         "react-dev-utils": "^4.2.1",
         "react-error-overlay": "^3.0.0",
         "react-hot-loader": "^4.1.0",
-        "react-lifecycles-compat": "^3.0.2",
         "redux": "^3.6.0",
         "relay-compiler": "1.5.0",
         "request": "^2.85.0",
-        "serve": "^9.2.0",
         "shallow-compare": "^1.2.2",
         "sift": "^5.1.0",
         "signal-exit": "^3.0.2",
@@ -9908,7 +8239,6 @@
         "socket.io": "^2.0.3",
         "string-similarity": "^1.2.0",
         "style-loader": "^0.21.0",
-        "treeify": "^1.1.0",
         "type-of": "^2.0.1",
         "uglifyjs-webpack-plugin": "^1.2.4",
         "url-loader": "^1.0.1",
@@ -9918,12 +8248,19 @@
         "webpack-dev-middleware": "^3.0.1",
         "webpack-dev-server": "^3.1.1",
         "webpack-hot-middleware": "^2.21.0",
-        "webpack-md5-hash": "^0.0.6",
         "webpack-merge": "^4.1.0",
         "webpack-stats-plugin": "^0.1.5",
         "yaml-loader": "^0.5.0"
       },
       "dependencies": {
+        "@babel/code-frame": {
+          "version": "7.0.0-beta.52",
+          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.52.tgz",
+          "integrity": "sha1-GSSDv6DR5GfBAVccIQKcy3SvKAE=",
+          "requires": {
+            "@babel/highlight": "7.0.0-beta.52"
+          }
+        },
         "@babel/core": {
           "version": "7.0.0-beta.52",
           "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.0.0-beta.52.tgz",
@@ -9944,6 +8281,18 @@
             "resolve": "^1.3.2",
             "semver": "^5.4.1",
             "source-map": "^0.5.0"
+          }
+        },
+        "@babel/generator": {
+          "version": "7.0.0-beta.52",
+          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.0.0-beta.52.tgz",
+          "integrity": "sha1-JpaPEvrYGM2XTISbKGtDfh6MzZE=",
+          "requires": {
+            "@babel/types": "7.0.0-beta.52",
+            "jsesc": "^2.5.1",
+            "lodash": "^4.17.5",
+            "source-map": "^0.5.0",
+            "trim-right": "^1.0.1"
           }
         },
         "@babel/helper-annotate-as-pure": {
@@ -10001,6 +8350,24 @@
             "@babel/types": "7.0.0-beta.52"
           }
         },
+        "@babel/helper-function-name": {
+          "version": "7.0.0-beta.52",
+          "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.0.0-beta.52.tgz",
+          "integrity": "sha1-qGelj/VxsldysteZsyhmBYVzxFA=",
+          "requires": {
+            "@babel/helper-get-function-arity": "7.0.0-beta.52",
+            "@babel/template": "7.0.0-beta.52",
+            "@babel/types": "7.0.0-beta.52"
+          }
+        },
+        "@babel/helper-get-function-arity": {
+          "version": "7.0.0-beta.52",
+          "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.52.tgz",
+          "integrity": "sha1-HAzaWOC3X0XpLq+9j+GJpO7pK3Q=",
+          "requires": {
+            "@babel/types": "7.0.0-beta.52"
+          }
+        },
         "@babel/helper-hoist-variables": {
           "version": "7.0.0-beta.52",
           "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.0.0-beta.52.tgz",
@@ -10015,6 +8382,15 @@
           "integrity": "sha1-sJjFTztyQFsqyOn2PiLj8GzJJxk=",
           "requires": {
             "@babel/types": "7.0.0-beta.52"
+          }
+        },
+        "@babel/helper-module-imports": {
+          "version": "7.0.0-beta.52",
+          "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.0.0-beta.52.tgz",
+          "integrity": "sha1-cIQOg66JH5RwLGxhN4fEjuPJZbs=",
+          "requires": {
+            "@babel/types": "7.0.0-beta.52",
+            "lodash": "^4.17.5"
           }
         },
         "@babel/helper-module-transforms": {
@@ -10037,6 +8413,11 @@
           "requires": {
             "@babel/types": "7.0.0-beta.52"
           }
+        },
+        "@babel/helper-plugin-utils": {
+          "version": "7.0.0-beta.52",
+          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0-beta.52.tgz",
+          "integrity": "sha1-LwWMX3w6X+S8IZA2sueOEb3et60="
         },
         "@babel/helper-regex": {
           "version": "7.0.0-beta.52",
@@ -10079,6 +8460,14 @@
             "lodash": "^4.17.5"
           }
         },
+        "@babel/helper-split-export-declaration": {
+          "version": "7.0.0-beta.52",
+          "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0-beta.52.tgz",
+          "integrity": "sha1-SqxPMOpjhK82duBLUkZydjLkYN8=",
+          "requires": {
+            "@babel/types": "7.0.0-beta.52"
+          }
+        },
         "@babel/helper-wrap-function": {
           "version": "7.0.0-beta.52",
           "resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.0.0-beta.52.tgz",
@@ -10099,6 +8488,21 @@
             "@babel/traverse": "7.0.0-beta.52",
             "@babel/types": "7.0.0-beta.52"
           }
+        },
+        "@babel/highlight": {
+          "version": "7.0.0-beta.52",
+          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-beta.52.tgz",
+          "integrity": "sha1-7ySTFDLwYVXnvDnNuKaze0oos9A=",
+          "requires": {
+            "chalk": "^2.0.0",
+            "esutils": "^2.0.2",
+            "js-tokens": "^3.0.0"
+          }
+        },
+        "@babel/parser": {
+          "version": "7.0.0-beta.52",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.0.0-beta.52.tgz",
+          "integrity": "sha1-TpNbYs2b+HK9N7zx9j2C/nsCN6I="
         },
         "@babel/plugin-proposal-async-generator-functions": {
           "version": "7.0.0-beta.52",
@@ -10537,10 +8941,48 @@
             "regenerator-runtime": "^0.12.0"
           }
         },
+        "@babel/template": {
+          "version": "7.0.0-beta.52",
+          "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.0.0-beta.52.tgz",
+          "integrity": "sha1-ROGPrDglH1f5JRHWdI8JWrAvmW4=",
+          "requires": {
+            "@babel/code-frame": "7.0.0-beta.52",
+            "@babel/parser": "7.0.0-beta.52",
+            "@babel/types": "7.0.0-beta.52",
+            "lodash": "^4.17.5"
+          }
+        },
+        "@babel/traverse": {
+          "version": "7.0.0-beta.52",
+          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.0.0-beta.52.tgz",
+          "integrity": "sha1-m4uplPcmTZhHhYrS/uzCc4xeLvM=",
+          "requires": {
+            "@babel/code-frame": "7.0.0-beta.52",
+            "@babel/generator": "7.0.0-beta.52",
+            "@babel/helper-function-name": "7.0.0-beta.52",
+            "@babel/helper-split-export-declaration": "7.0.0-beta.52",
+            "@babel/parser": "7.0.0-beta.52",
+            "@babel/types": "7.0.0-beta.52",
+            "debug": "^3.1.0",
+            "globals": "^11.1.0",
+            "invariant": "^2.2.0",
+            "lodash": "^4.17.5"
+          }
+        },
+        "@babel/types": {
+          "version": "7.0.0-beta.52",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.52.tgz",
+          "integrity": "sha1-o+ViCxU0slOlCrzyIitSDiOxbaI=",
+          "requires": {
+            "esutils": "^2.0.2",
+            "lodash": "^4.17.5",
+            "to-fast-properties": "^2.0.0"
+          }
+        },
         "gatsby-cli": {
-          "version": "2.0.0-beta.7",
-          "resolved": "https://registry.npmjs.org/gatsby-cli/-/gatsby-cli-2.0.0-beta.7.tgz",
-          "integrity": "sha1-zuvSQhFxE1AZ9MSU0zZxieq15oM=",
+          "version": "2.0.0-rc.0",
+          "resolved": "https://registry.npmjs.org/gatsby-cli/-/gatsby-cli-2.0.0-rc.0.tgz",
+          "integrity": "sha512-Qgq2ujV5+LFXvqKKq0a5Ry5DU/pcfXthfIcJaP28jHP2ODo2yk6FXRS2koaJijdB61+Yb9sOBqBDqyD6ktBsGA==",
           "requires": {
             "@babel/code-frame": "7.0.0-beta.52",
             "@babel/runtime": "7.0.0-beta.52",
@@ -10584,15 +9026,14 @@
       }
     },
     "gatsby-link": {
-      "version": "2.0.0-beta.7",
-      "resolved": "https://registry.npmjs.org/gatsby-link/-/gatsby-link-2.0.0-beta.7.tgz",
-      "integrity": "sha512-YT8ylxuPcXHKfYx9xP/jYl5//plDRrJow2hnFwSyLQ824LMyKK2cSTWHF/t8ydvjVmCBKU3SCrSzSoQqnjpuaQ==",
+      "version": "2.0.0-rc.0",
+      "resolved": "https://registry.npmjs.org/gatsby-link/-/gatsby-link-2.0.0-rc.0.tgz",
+      "integrity": "sha512-J36KEH51+7ZpQezi8q2ObKUw2zuc3zdS1/L3WrUkiFSGHjLdzbKHSY++j9Y86X3Yt8bqKcsEb5SpfY2XEkUtgA==",
       "requires": {
         "@babel/runtime": "7.0.0-beta.52",
-        "@types/history": "^4.6.2",
-        "@types/react-router-dom": "^4.2.5",
+        "@reach/router": "^1.1.1",
+        "@types/reach__router": "^1.0.0",
         "prop-types": "^15.6.1",
-        "react-lifecycles-compat": "^3.0.2",
         "ric": "^1.3.0"
       },
       "dependencies": {
@@ -10622,9 +9063,9 @@
       }
     },
     "gatsby-plugin-page-creator": {
-      "version": "2.0.0-beta.5",
-      "resolved": "https://registry.npmjs.org/gatsby-plugin-page-creator/-/gatsby-plugin-page-creator-2.0.0-beta.5.tgz",
-      "integrity": "sha1-NtGfz7ndctIT5VBveft8bq97VIs=",
+      "version": "2.0.0-rc.0",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-page-creator/-/gatsby-plugin-page-creator-2.0.0-rc.0.tgz",
+      "integrity": "sha512-6M/hBBxyc9cuySVqcSlNuGBcsIMs4ILY6BbaXOS51znxMnl0E2ocjtLBtkzfrxwo6XxzqDSpJS1Wf8td6sRfVQ==",
       "requires": {
         "@babel/runtime": "7.0.0-beta.52",
         "bluebird": "^3.5.0",
@@ -10766,9 +9207,9 @@
       }
     },
     "gatsby-plugin-react-helmet": {
-      "version": "3.0.0-beta.4",
-      "resolved": "https://registry.npmjs.org/gatsby-plugin-react-helmet/-/gatsby-plugin-react-helmet-3.0.0-beta.4.tgz",
-      "integrity": "sha1-Blu2f+w36G21NsUdelAG7uLOibk=",
+      "version": "3.0.0-rc.0",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-react-helmet/-/gatsby-plugin-react-helmet-3.0.0-rc.0.tgz",
+      "integrity": "sha512-xbaWbQt1m4vRP1toiowA6P5AaPf5SoHHaXunx8q1hEyJoFxZ+L1DIA4zru/g1GK9vlgmAzRjxjt/GYTRUb/CnA==",
       "requires": {
         "@babel/runtime": "7.0.0-beta.52"
       },
@@ -10790,9 +9231,9 @@
       }
     },
     "gatsby-react-router-scroll": {
-      "version": "2.0.0-beta.4",
-      "resolved": "https://registry.npmjs.org/gatsby-react-router-scroll/-/gatsby-react-router-scroll-2.0.0-beta.4.tgz",
-      "integrity": "sha512-g26sTBEaVbRfILjRZ7mOcXY2da9ypOsWHowkcedV6V67rxFfdS1jKeyu6amgdoRfrwl0SOwNvE0ItIIWeW7x+g==",
+      "version": "2.0.0-rc.0",
+      "resolved": "https://registry.npmjs.org/gatsby-react-router-scroll/-/gatsby-react-router-scroll-2.0.0-rc.0.tgz",
+      "integrity": "sha512-vsNnBPFAW3JuHxpdqhGqMNS0CMHC2wXr3e0ypKPI3FdvW7z4WZeT/komNAK9zsy4GpXqJ/PGo21duRGZvi5efw==",
       "requires": {
         "@babel/runtime": "7.0.0-beta.52",
         "scroll-behavior": "^0.9.9",
@@ -10950,21 +9391,6 @@
         }
       }
     },
-    "glob-slash": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/glob-slash/-/glob-slash-1.0.0.tgz",
-      "integrity": "sha1-/lLvpDMjP3Si/mTHq7m8hIICq5U="
-    },
-    "glob-slasher": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/glob-slasher/-/glob-slasher-1.0.1.tgz",
-      "integrity": "sha1-dHoOW7IiZC7hDT4FRD4QlJPLD44=",
-      "requires": {
-        "glob-slash": "^1.0.0",
-        "lodash.isobject": "^2.4.1",
-        "toxic": "^1.0.0"
-      }
-    },
     "glob-to-regexp": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.3.0.tgz",
@@ -11097,18 +9523,17 @@
       "integrity": "sha1-1oFebt1hjoeNXZIcE/xmAz7IZ+I="
     },
     "graphql-request": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/graphql-request/-/graphql-request-1.8.0.tgz",
-      "integrity": "sha512-kX4u/rPNd8EkYdYXDzAiGyVrLBZmdZREOlQVemcUkXtNVaNTh6eXC0yhmRypIB070/YtRl1w01xR1efOrHO+JA==",
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/graphql-request/-/graphql-request-1.8.2.tgz",
+      "integrity": "sha512-dDX2M+VMsxXFCmUX0Vo0TopIZIX4ggzOtiCsThgtrKR4niiaagsGTDIHj3fsOMFETpa064vzovI+4YV4QnMbcg==",
       "requires": {
-        "cross-fetch": "2.0.0",
-        "graphql": "^0.13.2"
+        "cross-fetch": "2.2.2"
       }
     },
     "graphql-skip-limit": {
-      "version": "2.0.0-beta.3",
-      "resolved": "https://registry.npmjs.org/graphql-skip-limit/-/graphql-skip-limit-2.0.0-beta.3.tgz",
-      "integrity": "sha1-40sPv+x1MvzJCvSwit+oegzyRys=",
+      "version": "2.0.0-rc.0",
+      "resolved": "https://registry.npmjs.org/graphql-skip-limit/-/graphql-skip-limit-2.0.0-rc.0.tgz",
+      "integrity": "sha512-UIpCep8LcbYwM7TbpyaDnrYY811oz4a9x2CkK+inz32vh9V54fwe8ml4y2bYJ+B/+cX44zFeCMS3Rg0oP8SM2g==",
       "requires": {
         "@babel/runtime": "7.0.0-beta.52"
       },
@@ -11265,11 +9690,11 @@
       "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
     },
     "har-validator": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
-      "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.0.tgz",
+      "integrity": "sha512-+qnmNjI4OfH2ipQ9VQOw23bBd/ibtfbVdK2fYbY4acTDqKTW/YDp9McimZdDbG8iV9fZizUqQMD5xvriB146TA==",
       "requires": {
-        "ajv": "^5.1.0",
+        "ajv": "^5.3.0",
         "har-schema": "^2.0.0"
       }
     },
@@ -11393,18 +9818,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/hex-color-regex/-/hex-color-regex-1.1.0.tgz",
       "integrity": "sha512-l9sfDFsuqtOqKDsQdqrMRk0U85RZc0RtOR9yPI7mRVOa4FsR/BVnZ0shmQRM96Ji99kYZP/7hn1cedc1+ApsTQ=="
-    },
-    "history": {
-      "version": "4.7.2",
-      "resolved": "https://registry.npmjs.org/history/-/history-4.7.2.tgz",
-      "integrity": "sha512-1zkBRWW6XweO0NBcjiphtVJVsIQ+SXF29z9DVkceeaSLVMFXHool+fdCZD4spDCfZJCILPILc3bm7Bc+HRi0nA==",
-      "requires": {
-        "invariant": "^2.2.1",
-        "loose-envify": "^1.2.0",
-        "resolve-pathname": "^2.2.0",
-        "value-equal": "^0.4.0",
-        "warning": "^3.0.0"
-      }
     },
     "hmac-drbg": {
       "version": "1.0.1",
@@ -11941,11 +10354,11 @@
       "integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA=="
     },
     "is-ci": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.1.0.tgz",
-      "integrity": "sha512-c7TnwxLePuqIlxHgr7xtxzycJPegNHFuIrBkwbf8hc58//+Op1CqFkyS+xnIMkwn9UsJIwc174BIjkyBmSpjKg==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.2.0.tgz",
+      "integrity": "sha512-plgvKjQtalH2P3Gytb7L61Lmz95g2DlpzFiQyRSFew8WoJKxtKRzrZMeyRN2supblm3Psc8OQGy7Xjb6XG11jw==",
       "requires": {
-        "ci-info": "^1.0.0"
+        "ci-info": "^1.3.0"
       }
     },
     "is-color-stop": {
@@ -12403,13 +10816,13 @@
       "integrity": "sha512-yynBb1g+RFUPY64fTrFv7nsjRrENBQJaX2UL+2Szc9REFrSNm1rpSXHGzhmAy7a9uv3vlvgBlXnf9RqmPH1/DA=="
     },
     "jest": {
-      "version": "23.4.2",
-      "resolved": "https://registry.npmjs.org/jest/-/jest-23.4.2.tgz",
-      "integrity": "sha512-w10HGpVFWT1oN8B2coxeiMEsZoggkDaw3i26xHGLU+rsR+LYkBk8qpZCgi+1cD1S6ttPjZDL8E8M99lmNhgTeA==",
+      "version": "23.5.0",
+      "resolved": "https://registry.npmjs.org/jest/-/jest-23.5.0.tgz",
+      "integrity": "sha512-+X3Fk4rD8dTnHoIxHJymZthbtYllvSOnXAApQltvyLkHsv+fqyC/SZptUJDbXkFsqZJyyIXMySkdzerz3fv4oQ==",
       "dev": true,
       "requires": {
         "import-local": "^1.0.0",
-        "jest-cli": "^23.4.2"
+        "jest-cli": "^23.5.0"
       },
       "dependencies": {
         "ansi-regex": {
@@ -12478,9 +10891,9 @@
           }
         },
         "jest-cli": {
-          "version": "23.4.2",
-          "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-23.4.2.tgz",
-          "integrity": "sha512-vaDzy0wRWrgSfz4ZImCqD2gtZqCSoEWp60y3USvGDxA2b4K0rGj2voru6a5scJFjDx5GCiNWKpz2E8IdWDVjdw==",
+          "version": "23.5.0",
+          "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-23.5.0.tgz",
+          "integrity": "sha512-Kxi2QH8s6NkpPgboza/plpmQ2bjUQ+MwYv7vM5rDwJz/x+NB4YoLXFikPXLWNP0JuYpMvYwITKneFljnNKhq2Q==",
           "dev": true,
           "requires": {
             "ansi-escapes": "^3.0.0",
@@ -12495,18 +10908,18 @@
             "istanbul-lib-instrument": "^1.10.1",
             "istanbul-lib-source-maps": "^1.2.4",
             "jest-changed-files": "^23.4.2",
-            "jest-config": "^23.4.2",
+            "jest-config": "^23.5.0",
             "jest-environment-jsdom": "^23.4.0",
             "jest-get-type": "^22.1.0",
-            "jest-haste-map": "^23.4.1",
+            "jest-haste-map": "^23.5.0",
             "jest-message-util": "^23.4.0",
             "jest-regex-util": "^23.3.0",
-            "jest-resolve-dependencies": "^23.4.2",
-            "jest-runner": "^23.4.2",
-            "jest-runtime": "^23.4.2",
-            "jest-snapshot": "^23.4.2",
+            "jest-resolve-dependencies": "^23.5.0",
+            "jest-runner": "^23.5.0",
+            "jest-runtime": "^23.5.0",
+            "jest-snapshot": "^23.5.0",
             "jest-util": "^23.4.0",
-            "jest-validate": "^23.4.0",
+            "jest-validate": "^23.5.0",
             "jest-watcher": "^23.4.0",
             "jest-worker": "^23.2.0",
             "micromatch": "^2.3.11",
@@ -12572,9 +10985,9 @@
       }
     },
     "jest-config": {
-      "version": "23.4.2",
-      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-23.4.2.tgz",
-      "integrity": "sha512-CDJGO4H+7P+T6khaSHEjTxqVaIlmQMEFAyJFOVrAQeM+Xn12iZ+YY8Pluk1RDxi8Jqj9DoE09PHQzASCGePGtg==",
+      "version": "23.5.0",
+      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-23.5.0.tgz",
+      "integrity": "sha512-JENhQpLaVwXWPLUkhPYgIfecHKsU8GR1vj79rS4n0LSRsHx/U2wItZKoKAd5vtt2J58JPxRq4XheG79jd4fI7Q==",
       "dev": true,
       "requires": {
         "babel-core": "^6.0.0",
@@ -12584,14 +10997,30 @@
         "jest-environment-jsdom": "^23.4.0",
         "jest-environment-node": "^23.4.0",
         "jest-get-type": "^22.1.0",
-        "jest-jasmine2": "^23.4.2",
+        "jest-jasmine2": "^23.5.0",
         "jest-regex-util": "^23.3.0",
-        "jest-resolve": "^23.4.1",
+        "jest-resolve": "^23.5.0",
         "jest-util": "^23.4.0",
-        "jest-validate": "^23.4.0",
-        "pretty-format": "^23.2.0"
+        "jest-validate": "^23.5.0",
+        "micromatch": "^2.3.11",
+        "pretty-format": "^23.5.0"
       },
       "dependencies": {
+        "arr-diff": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
+          "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
+          "dev": true,
+          "requires": {
+            "arr-flatten": "^1.0.1"
+          }
+        },
+        "array-unique": {
+          "version": "0.2.1",
+          "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
+          "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
+          "dev": true
+        },
         "babel-core": {
           "version": "6.26.3",
           "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.3.tgz",
@@ -12625,6 +11054,17 @@
           "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
           "dev": true
         },
+        "braces": {
+          "version": "1.8.5",
+          "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
+          "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
+          "dev": true,
+          "requires": {
+            "expand-range": "^1.8.1",
+            "preserve": "^0.2.0",
+            "repeat-element": "^1.1.2"
+          }
+        },
         "debug": {
           "version": "2.6.9",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -12633,19 +11073,82 @@
           "requires": {
             "ms": "2.0.0"
           }
+        },
+        "expand-brackets": {
+          "version": "0.1.5",
+          "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
+          "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
+          "dev": true,
+          "requires": {
+            "is-posix-bracket": "^0.1.0"
+          }
+        },
+        "extglob": {
+          "version": "0.3.2",
+          "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
+          "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
+          "dev": true,
+          "requires": {
+            "is-extglob": "^1.0.0"
+          }
+        },
+        "is-extglob": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+          "dev": true
+        },
+        "is-glob": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+          "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+          "dev": true,
+          "requires": {
+            "is-extglob": "^1.0.0"
+          }
+        },
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        },
+        "micromatch": {
+          "version": "2.3.11",
+          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
+          "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
+          "dev": true,
+          "requires": {
+            "arr-diff": "^2.0.0",
+            "array-unique": "^0.2.1",
+            "braces": "^1.8.2",
+            "expand-brackets": "^0.1.4",
+            "extglob": "^0.3.1",
+            "filename-regex": "^2.0.0",
+            "is-extglob": "^1.0.0",
+            "is-glob": "^2.0.1",
+            "kind-of": "^3.0.2",
+            "normalize-path": "^2.0.1",
+            "object.omit": "^2.0.0",
+            "parse-glob": "^3.0.4",
+            "regex-cache": "^0.4.2"
+          }
         }
       }
     },
     "jest-diff": {
-      "version": "23.2.0",
-      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-23.2.0.tgz",
-      "integrity": "sha1-nyz0tR4Sx5FVAgCrwWtHEwrxBio=",
+      "version": "23.5.0",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-23.5.0.tgz",
+      "integrity": "sha512-Miz8GakJIz443HkGpVOAyHQgSYqcgs2zQmDJl4oV7DYrFotchdoQvxceF6LhfpRBV1LOUGcFk5Dd/ffSXVwMsA==",
       "dev": true,
       "requires": {
         "chalk": "^2.0.1",
         "diff": "^3.2.0",
         "jest-get-type": "^22.1.0",
-        "pretty-format": "^23.2.0"
+        "pretty-format": "^23.5.0"
       }
     },
     "jest-docblock": {
@@ -12658,13 +11161,13 @@
       }
     },
     "jest-each": {
-      "version": "23.4.0",
-      "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-23.4.0.tgz",
-      "integrity": "sha1-L6nt2J2qGk7cn/m/YGKja3E0UUM=",
+      "version": "23.5.0",
+      "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-23.5.0.tgz",
+      "integrity": "sha512-8BgebQgAJmWXpYp4Qt9l3cn1Xei0kZ7JL4cs/NXh7750ATlPGzRRYbutFVJTk5B/Lt3mjHP3G3tLQLyBOCSHGA==",
       "dev": true,
       "requires": {
         "chalk": "^2.0.1",
-        "pretty-format": "^23.2.0"
+        "pretty-format": "^23.5.0"
       }
     },
     "jest-environment-jsdom": {
@@ -12695,13 +11198,14 @@
       "dev": true
     },
     "jest-haste-map": {
-      "version": "23.4.1",
-      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-23.4.1.tgz",
-      "integrity": "sha512-PGQxOEGAfRbTyJkmZeOKkVSs+KVeWgG625p89KUuq+sIIchY5P8iPIIc+Hw2tJJPBzahU3qopw1kF/qyhDdNBw==",
+      "version": "23.5.0",
+      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-23.5.0.tgz",
+      "integrity": "sha512-bt9Swigb6KZ6ZQq/fQDUwdUeHenVvZ6G/lKwJjwRGp+Fap8D4B3bND3FaeJg7vXVsLX8hXshRArbVxLop/5wLw==",
       "dev": true,
       "requires": {
         "fb-watchman": "^2.0.0",
         "graceful-fs": "^4.1.11",
+        "invariant": "^2.2.4",
         "jest-docblock": "^23.2.0",
         "jest-serializer": "^23.0.1",
         "jest-worker": "^23.2.0",
@@ -12801,43 +11305,43 @@
       }
     },
     "jest-jasmine2": {
-      "version": "23.4.2",
-      "resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-23.4.2.tgz",
-      "integrity": "sha512-MUoqn41XHMQe5u8QvRTH2HahpBNzImnnjS3pV/T7LvrCM6f2zfGdi1Pm+bRbFMLJROqR8VlK8HmsenL2WjrUIQ==",
+      "version": "23.5.0",
+      "resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-23.5.0.tgz",
+      "integrity": "sha512-xMgvDUvgqKpilsGnneC9Qr+uIlROxKI3UoJcHZeUlu6AKpQyEkGh0hKbfM0NaEjX5sy7WeFQEhcp/AiWlHcc0A==",
       "dev": true,
       "requires": {
         "babel-traverse": "^6.0.0",
         "chalk": "^2.0.1",
         "co": "^4.6.0",
-        "expect": "^23.4.0",
+        "expect": "^23.5.0",
         "is-generator-fn": "^1.0.0",
-        "jest-diff": "^23.2.0",
-        "jest-each": "^23.4.0",
-        "jest-matcher-utils": "^23.2.0",
+        "jest-diff": "^23.5.0",
+        "jest-each": "^23.5.0",
+        "jest-matcher-utils": "^23.5.0",
         "jest-message-util": "^23.4.0",
-        "jest-snapshot": "^23.4.2",
+        "jest-snapshot": "^23.5.0",
         "jest-util": "^23.4.0",
-        "pretty-format": "^23.2.0"
+        "pretty-format": "^23.5.0"
       }
     },
     "jest-leak-detector": {
-      "version": "23.2.0",
-      "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-23.2.0.tgz",
-      "integrity": "sha1-wonZYdxjjxQ1fU75bgQx7MGqN30=",
+      "version": "23.5.0",
+      "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-23.5.0.tgz",
+      "integrity": "sha512-40VsHQCIEslxg91Zg5NiZGtPeWSBLXiD6Ww+lhHlIF6u8uSQ+xgiD6NbWHFOYs1VBRI+V/ym7Q1aOtVg9tqMzQ==",
       "dev": true,
       "requires": {
-        "pretty-format": "^23.2.0"
+        "pretty-format": "^23.5.0"
       }
     },
     "jest-matcher-utils": {
-      "version": "23.2.0",
-      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-23.2.0.tgz",
-      "integrity": "sha1-TUmB8jIT6Tnjzt8j3DTHR7WuGRM=",
+      "version": "23.5.0",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-23.5.0.tgz",
+      "integrity": "sha512-hmQUKUKYOExp3T8dNYK9A9copCFYKoRLcY4WDJJ0Z2u3oF6rmAhHuZtmpHBuGpASazobBxm3TXAfAXDvz2T7+Q==",
       "dev": true,
       "requires": {
         "chalk": "^2.0.1",
         "jest-get-type": "^22.1.0",
-        "pretty-format": "^23.2.0"
+        "pretty-format": "^23.5.0"
       }
     },
     "jest-message-util": {
@@ -12957,9 +11461,9 @@
       "dev": true
     },
     "jest-resolve": {
-      "version": "23.4.1",
-      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-23.4.1.tgz",
-      "integrity": "sha512-VNk4YRNR5gsHhNS0Lp46/DzTT11e+ecbUC61ikE593cKbtdrhrMO+zXkOJaE8YDD5sHxH9W6OfssNn4FkZBzZQ==",
+      "version": "23.5.0",
+      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-23.5.0.tgz",
+      "integrity": "sha512-CRPc0ebG3baNKz/QicIy5rGfzYpMNm8AjEl/tDQhehq/QC4ttyauZdvAXel3qo+4Gri9ljajnxW+hWyxZbbcnQ==",
       "dev": true,
       "requires": {
         "browser-resolve": "^1.11.3",
@@ -12968,30 +11472,30 @@
       }
     },
     "jest-resolve-dependencies": {
-      "version": "23.4.2",
-      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-23.4.2.tgz",
-      "integrity": "sha512-JUrU1/1mQAf0eKwKT4+RRnaqcw0UcRzRE38vyO+YnqoXUVidf646iuaKE+NG7E6Gb0+EVPOJ6TgqkaTPdQz78A==",
+      "version": "23.5.0",
+      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-23.5.0.tgz",
+      "integrity": "sha512-APZc/CjfzL8rH/wr+Gh7XJJygYaDjMQsWaJy4ZR1WaHWKude4WcfdU8xjqaNbx5NsVF2P2tVvsLbumlPXCdJOw==",
       "dev": true,
       "requires": {
         "jest-regex-util": "^23.3.0",
-        "jest-snapshot": "^23.4.2"
+        "jest-snapshot": "^23.5.0"
       }
     },
     "jest-runner": {
-      "version": "23.4.2",
-      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-23.4.2.tgz",
-      "integrity": "sha512-o+aEdDE7/Gyp8fLYEEf5B8aOUguz76AYcAMl5pueucey2Q50O8uUIXJ7zvt8O6OEJDztR3Kb+osMoh8MVIqgTw==",
+      "version": "23.5.0",
+      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-23.5.0.tgz",
+      "integrity": "sha512-cpBvkBTVmW1ab1thbtoh2m6VnnM0BYKhj3MEzbOTZjPfzoIjUVIxLUTDobVNOvEK7aTEb/2oiPlNoOTSNJx8mw==",
       "dev": true,
       "requires": {
         "exit": "^0.1.2",
         "graceful-fs": "^4.1.11",
-        "jest-config": "^23.4.2",
+        "jest-config": "^23.5.0",
         "jest-docblock": "^23.2.0",
-        "jest-haste-map": "^23.4.1",
-        "jest-jasmine2": "^23.4.2",
-        "jest-leak-detector": "^23.2.0",
+        "jest-haste-map": "^23.5.0",
+        "jest-jasmine2": "^23.5.0",
+        "jest-leak-detector": "^23.5.0",
         "jest-message-util": "^23.4.0",
-        "jest-runtime": "^23.4.2",
+        "jest-runtime": "^23.5.0",
         "jest-util": "^23.4.0",
         "jest-worker": "^23.2.0",
         "source-map-support": "^0.5.6",
@@ -13005,9 +11509,9 @@
           "dev": true
         },
         "source-map-support": {
-          "version": "0.5.6",
-          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.6.tgz",
-          "integrity": "sha512-N4KXEz7jcKqPf2b2vZF11lQIz9W5ZMuUcIOGj243lduidkf2fjkVKJS9vNxVWn3u/uxX38AcE8U9nnH9FPcq+g==",
+          "version": "0.5.9",
+          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.9.tgz",
+          "integrity": "sha512-gR6Rw4MvUlYy83vP0vxoVNzM6t8MUXqNuRsuBmBHQDu1Fh6X015FrLdgoDKcNdkwGubozq0P4N0Q37UyFVr1EA==",
           "dev": true,
           "requires": {
             "buffer-from": "^1.0.0",
@@ -13017,9 +11521,9 @@
       }
     },
     "jest-runtime": {
-      "version": "23.4.2",
-      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-23.4.2.tgz",
-      "integrity": "sha512-qaUDOi7tcdDe3MH5g5ycEslTpx0voPZvzIYbKjvWxCzCL2JEemLM+7IEe0BeLi2v5wvb/uh3dkb2wQI67uPtCw==",
+      "version": "23.5.0",
+      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-23.5.0.tgz",
+      "integrity": "sha512-WzzYxYtoU8S1MJns0G4E3BsuFUTFBiu1qsk3iC9OTugzNQcQKt0BoOGsT7wXCKqkw/09QdV77vvaeJXST2Efgg==",
       "dev": true,
       "requires": {
         "babel-core": "^6.0.0",
@@ -13029,14 +11533,14 @@
         "exit": "^0.1.2",
         "fast-json-stable-stringify": "^2.0.0",
         "graceful-fs": "^4.1.11",
-        "jest-config": "^23.4.2",
-        "jest-haste-map": "^23.4.1",
+        "jest-config": "^23.5.0",
+        "jest-haste-map": "^23.5.0",
         "jest-message-util": "^23.4.0",
         "jest-regex-util": "^23.3.0",
-        "jest-resolve": "^23.4.1",
-        "jest-snapshot": "^23.4.2",
+        "jest-resolve": "^23.5.0",
+        "jest-snapshot": "^23.5.0",
         "jest-util": "^23.4.0",
-        "jest-validate": "^23.4.0",
+        "jest-validate": "^23.5.0",
         "micromatch": "^2.3.11",
         "realpath-native": "^1.0.0",
         "slash": "^1.0.0",
@@ -13185,20 +11689,20 @@
       "dev": true
     },
     "jest-snapshot": {
-      "version": "23.4.2",
-      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-23.4.2.tgz",
-      "integrity": "sha512-rCBxIURDlVEW1gJgJSpo8l2F2gFwp9U7Yb3CmcABUpmQ8NASpb6LJkEvtcQifAYSi22OL44TSuanq1G6x1GJwg==",
+      "version": "23.5.0",
+      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-23.5.0.tgz",
+      "integrity": "sha512-NYg8MFNVyPXmnnihiltasr4t1FJEXFbZFaw1vZCowcnezIQ9P1w+yxTwjWT564QP24Zbn5L9cjxLs8d6K+pNlw==",
       "dev": true,
       "requires": {
         "babel-types": "^6.0.0",
         "chalk": "^2.0.1",
-        "jest-diff": "^23.2.0",
-        "jest-matcher-utils": "^23.2.0",
+        "jest-diff": "^23.5.0",
+        "jest-matcher-utils": "^23.5.0",
         "jest-message-util": "^23.4.0",
-        "jest-resolve": "^23.4.1",
+        "jest-resolve": "^23.5.0",
         "mkdirp": "^0.5.1",
         "natural-compare": "^1.4.0",
-        "pretty-format": "^23.2.0",
+        "pretty-format": "^23.5.0",
         "semver": "^5.5.0"
       }
     },
@@ -13233,15 +11737,15 @@
       }
     },
     "jest-validate": {
-      "version": "23.4.0",
-      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-23.4.0.tgz",
-      "integrity": "sha1-2W7t4B7wOskJwAnpyORVGX1IwgE=",
+      "version": "23.5.0",
+      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-23.5.0.tgz",
+      "integrity": "sha512-XmStdYhfdiDKacXX5sNqEE61Zz4/yXaPcDsKvVA0429RBu2pkQyIltCVG7UitJIEAzSs3ociQTdyseAW8VGPiA==",
       "dev": true,
       "requires": {
         "chalk": "^2.0.1",
         "jest-get-type": "^22.1.0",
         "leven": "^2.1.0",
-        "pretty-format": "^23.2.0"
+        "pretty-format": "^23.5.0"
       }
     },
     "jest-watcher": {
@@ -13605,21 +12109,11 @@
       "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.10.tgz",
       "integrity": "sha512-iesFYPmxYYGTcmQK0sL8bX3TGHyM6b2qREaB4kamHfQyfPJP0xgoGxp19nsH16nsfquLdiyKyX3mQkfiSGV8Rg=="
     },
-    "lodash-id": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/lodash-id/-/lodash-id-0.14.0.tgz",
-      "integrity": "sha1-uvSJNOVDobXWNG+MhGmLGoyAOJY="
-    },
     "lodash._getnative": {
       "version": "3.9.1",
       "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
       "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=",
       "dev": true
-    },
-    "lodash._objecttypes": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/lodash._objecttypes/-/lodash._objecttypes-2.4.1.tgz",
-      "integrity": "sha1-fAt/admKH3ZSn4kLDNsbTf7BHBE="
     },
     "lodash.camelcase": {
       "version": "4.3.0",
@@ -13654,14 +12148,6 @@
       "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
       "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA=",
       "dev": true
-    },
-    "lodash.isobject": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-2.4.1.tgz",
-      "integrity": "sha1-Wi5H/mmVPx7mMafrof5k0tBlWPU=",
-      "requires": {
-        "lodash._objecttypes": "~2.4.1"
-      }
     },
     "lodash.isplainobject": {
       "version": "4.0.6",
@@ -13772,17 +12258,6 @@
       "requires": {
         "currently-unhandled": "^0.4.1",
         "signal-exit": "^3.0.0"
-      }
-    },
-    "lowdb": {
-      "version": "0.16.2",
-      "resolved": "https://registry.npmjs.org/lowdb/-/lowdb-0.16.2.tgz",
-      "integrity": "sha1-oql262bsV3lykZcPPIfNthEm+jo=",
-      "requires": {
-        "graceful-fs": "^4.1.3",
-        "is-promise": "^2.1.0",
-        "lodash": "4",
-        "steno": "^0.4.1"
       }
     },
     "lower-case": {
@@ -14108,13 +12583,51 @@
       }
     },
     "mini-css-extract-plugin": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-0.4.1.tgz",
-      "integrity": "sha512-XWuB3G61Rtasq/gLe7cp5cuozehE6hN+E4sxCamRR/WDiHTg+f7ZIAS024r8UJQffY+e2gGELXQZgQoFDfNDCg==",
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-0.4.2.tgz",
+      "integrity": "sha512-ots7URQH4wccfJq9Ssrzu2+qupbncAce4TmTzunI9CIwlQMp2XI+WNUw6xWF6MMAGAm1cbUVINrSjATaVMyKXg==",
       "requires": {
-        "@webpack-contrib/schema-utils": "^1.0.0-beta.0",
         "loader-utils": "^1.1.0",
+        "schema-utils": "^1.0.0",
         "webpack-sources": "^1.1.0"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "6.5.3",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.5.3.tgz",
+          "integrity": "sha512-LqZ9wY+fx3UMiiPd741yB2pj3hhil+hQc8taf4o2QGRFpWgZ2V5C8HA165DY9sS3fJwsk7uT7ZlFEyC3Ig3lLg==",
+          "requires": {
+            "fast-deep-equal": "^2.0.1",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.4.1",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "ajv-keywords": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.2.0.tgz",
+          "integrity": "sha1-6GuBnGAs+IIa1jdBNpjx3sAhhHo="
+        },
+        "fast-deep-equal": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+          "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
+        },
+        "json-schema-traverse": {
+          "version": "0.4.1",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+          "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+        },
+        "schema-utils": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-1.0.0.tgz",
+          "integrity": "sha512-i27Mic4KovM/lnGsy8whRCHhc7VicJajAjTrYg11K9zfZXnYIt4k5F+kZkwjnrhKzLic/HLU4j11mjsz2G/75g==",
+          "requires": {
+            "ajv": "^6.1.0",
+            "ajv-errors": "^1.0.0",
+            "ajv-keywords": "^3.1.0"
+          }
+        }
       }
     },
     "minimalistic-assert": {
@@ -14272,9 +12785,9 @@
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc="
     },
     "nearley": {
-      "version": "2.15.0",
-      "resolved": "https://registry.npmjs.org/nearley/-/nearley-2.15.0.tgz",
-      "integrity": "sha512-ZjzdO+yBtMrRrBbr+BJ35ECla6PGCAb/6hqpBQe7bmhEJabQ4rpVdj4sadP1Z1jQGyaDmm1GciQWsGVxIZ3uJA==",
+      "version": "2.15.1",
+      "resolved": "https://registry.npmjs.org/nearley/-/nearley-2.15.1.tgz",
+      "integrity": "sha512-8IUY/rUrKz2mIynUGh8k+tul1awMKEjeHHC5G3FHvvyAW6oq4mQfNp2c0BMea+sYZJvYcrrM6GmZVIle/GRXGw==",
       "dev": true,
       "requires": {
         "moo": "^0.4.3",
@@ -14408,6 +12921,7 @@
       "version": "1.0.0-alpha.10",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.0.0-alpha.10.tgz",
       "integrity": "sha512-BSQrRgOfN6L/MoKIa7pRUc7dHvflCXMcqyTBvphixcSsgJTuUd24vAFONuNfVsuwTyz28S1HEc9XN6ZKylk4Hg==",
+      "dev": true,
       "requires": {
         "semver": "^5.3.0"
       }
@@ -14420,14 +12934,6 @@
       "requires": {
         "colors": "0.5.x",
         "underscore": "~1.4.4"
-      },
-      "dependencies": {
-        "colors": {
-          "version": "0.5.1",
-          "resolved": "https://registry.npmjs.org/colors/-/colors-0.5.1.tgz",
-          "integrity": "sha1-fQAj6usVTo7p/Oddy5I9DtFmd3Q=",
-          "dev": true
-        }
       }
     },
     "noms": {
@@ -14550,9 +13056,9 @@
       "dev": true
     },
     "oauth-sign": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
-      "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM="
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
+      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
     },
     "object-assign": {
       "version": "4.1.1",
@@ -15127,9 +13633,9 @@
       "dev": true
     },
     "portfinder": {
-      "version": "1.0.15",
-      "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.15.tgz",
-      "integrity": "sha512-THpr3TlxP1bPXp7jtuxk43cs7zyckFyO5AiNf93X7e67xs26BULEqaBxXILG9LULOHaKQwkR4cvrlhzVyHV/TA==",
+      "version": "1.0.17",
+      "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.17.tgz",
+      "integrity": "sha512-syFcRIRzVI1BoEFOCaAiizwDolh1S1YXSodsVhncbhjzjZQulhczNRbqnUl9N31Q4dKGOXsNDqxC2BWBgSMqeQ==",
       "requires": {
         "async": "^1.5.2",
         "debug": "^2.2.0",
@@ -15197,13 +13703,31 @@
       },
       "dependencies": {
         "browserslist": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.0.1.tgz",
-          "integrity": "sha512-QqiiIWchEIkney3wY53/huI7ZErouNAdvOkjorUALAwRcu3tEwOV3Sh6He0DnP38mz1JjBpCBb50jQBmaYuHPw==",
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.0.2.tgz",
+          "integrity": "sha512-lpujC4zv1trcKUUwfD4pFVNga4YSpB3sLB+/I+A8gvGQxno1c0dMB2aCQy0FE5oUNIDjD9puFiFF0zeS6Ji48w==",
           "requires": {
-            "caniuse-lite": "^1.0.30000865",
-            "electron-to-chromium": "^1.3.52",
-            "node-releases": "^1.0.0-alpha.10"
+            "caniuse-lite": "^1.0.30000876",
+            "electron-to-chromium": "^1.3.57",
+            "node-releases": "^1.0.0-alpha.11"
+          }
+        },
+        "caniuse-lite": {
+          "version": "1.0.30000878",
+          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000878.tgz",
+          "integrity": "sha512-/dCGTdLCnjVJno1mFRn7Y6eit3AYaeFzSrMQHCoK0LEQaWl5snuLex1Ky4b8/Qu2ig5NgTX4cJx65hH9546puA=="
+        },
+        "electron-to-chromium": {
+          "version": "1.3.59",
+          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.59.tgz",
+          "integrity": "sha512-PbJGGpDSNn3fyUN1eQESAmnMT+a1QAO4NEZgikDuGOn7tbAuMHF87jNna+NoVsMBfEEYzfpn/ay88HgDCJUbQA=="
+        },
+        "node-releases": {
+          "version": "1.0.0-alpha.11",
+          "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.0.0-alpha.11.tgz",
+          "integrity": "sha512-CaViu+2FqTNYOYNihXa5uPS/zry92I3vPU4nCB6JB3OeZ2UGtOpF5gRwuN4+m3hbEcL47bOXyun1jX2iC+3uEQ==",
+          "requires": {
+            "semver": "^5.3.0"
           }
         }
       }
@@ -15315,13 +13839,31 @@
       },
       "dependencies": {
         "browserslist": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.0.1.tgz",
-          "integrity": "sha512-QqiiIWchEIkney3wY53/huI7ZErouNAdvOkjorUALAwRcu3tEwOV3Sh6He0DnP38mz1JjBpCBb50jQBmaYuHPw==",
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.0.2.tgz",
+          "integrity": "sha512-lpujC4zv1trcKUUwfD4pFVNga4YSpB3sLB+/I+A8gvGQxno1c0dMB2aCQy0FE5oUNIDjD9puFiFF0zeS6Ji48w==",
           "requires": {
-            "caniuse-lite": "^1.0.30000865",
-            "electron-to-chromium": "^1.3.52",
-            "node-releases": "^1.0.0-alpha.10"
+            "caniuse-lite": "^1.0.30000876",
+            "electron-to-chromium": "^1.3.57",
+            "node-releases": "^1.0.0-alpha.11"
+          }
+        },
+        "caniuse-lite": {
+          "version": "1.0.30000878",
+          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000878.tgz",
+          "integrity": "sha512-/dCGTdLCnjVJno1mFRn7Y6eit3AYaeFzSrMQHCoK0LEQaWl5snuLex1Ky4b8/Qu2ig5NgTX4cJx65hH9546puA=="
+        },
+        "electron-to-chromium": {
+          "version": "1.3.59",
+          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.59.tgz",
+          "integrity": "sha512-PbJGGpDSNn3fyUN1eQESAmnMT+a1QAO4NEZgikDuGOn7tbAuMHF87jNna+NoVsMBfEEYzfpn/ay88HgDCJUbQA=="
+        },
+        "node-releases": {
+          "version": "1.0.0-alpha.11",
+          "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.0.0-alpha.11.tgz",
+          "integrity": "sha512-CaViu+2FqTNYOYNihXa5uPS/zry92I3vPU4nCB6JB3OeZ2UGtOpF5gRwuN4+m3hbEcL47bOXyun1jX2iC+3uEQ==",
+          "requires": {
+            "semver": "^5.3.0"
           }
         },
         "postcss-selector-parser": {
@@ -15537,13 +14079,31 @@
       },
       "dependencies": {
         "browserslist": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.0.1.tgz",
-          "integrity": "sha512-QqiiIWchEIkney3wY53/huI7ZErouNAdvOkjorUALAwRcu3tEwOV3Sh6He0DnP38mz1JjBpCBb50jQBmaYuHPw==",
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.0.2.tgz",
+          "integrity": "sha512-lpujC4zv1trcKUUwfD4pFVNga4YSpB3sLB+/I+A8gvGQxno1c0dMB2aCQy0FE5oUNIDjD9puFiFF0zeS6Ji48w==",
           "requires": {
-            "caniuse-lite": "^1.0.30000865",
-            "electron-to-chromium": "^1.3.52",
-            "node-releases": "^1.0.0-alpha.10"
+            "caniuse-lite": "^1.0.30000876",
+            "electron-to-chromium": "^1.3.57",
+            "node-releases": "^1.0.0-alpha.11"
+          }
+        },
+        "caniuse-lite": {
+          "version": "1.0.30000878",
+          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000878.tgz",
+          "integrity": "sha512-/dCGTdLCnjVJno1mFRn7Y6eit3AYaeFzSrMQHCoK0LEQaWl5snuLex1Ky4b8/Qu2ig5NgTX4cJx65hH9546puA=="
+        },
+        "electron-to-chromium": {
+          "version": "1.3.59",
+          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.59.tgz",
+          "integrity": "sha512-PbJGGpDSNn3fyUN1eQESAmnMT+a1QAO4NEZgikDuGOn7tbAuMHF87jNna+NoVsMBfEEYzfpn/ay88HgDCJUbQA=="
+        },
+        "node-releases": {
+          "version": "1.0.0-alpha.11",
+          "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.0.0-alpha.11.tgz",
+          "integrity": "sha512-CaViu+2FqTNYOYNihXa5uPS/zry92I3vPU4nCB6JB3OeZ2UGtOpF5gRwuN4+m3hbEcL47bOXyun1jX2iC+3uEQ==",
+          "requires": {
+            "semver": "^5.3.0"
           }
         }
       }
@@ -15611,9 +14171,9 @@
       "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks="
     },
     "prettier": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.14.0.tgz",
-      "integrity": "sha512-KtQ2EGaUwf2EyDfp1fxyEb0PqGKakVm0WyXwDt6u+cAoxbO2Z2CwKvOe3+b4+F2IlO9lYHi1kqFuRM70ddBnow==",
+      "version": "1.14.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.14.2.tgz",
+      "integrity": "sha512-McHPg0n1pIke+A/4VcaS2en+pTNjy4xF+Uuq86u/5dyDO59/TtFZtQ708QIRkEZ3qwKz3GVkVa6mpxK/CpB8Rg==",
       "dev": true
     },
     "pretty-error": {
@@ -15626,9 +14186,9 @@
       }
     },
     "pretty-format": {
-      "version": "23.2.0",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-23.2.0.tgz",
-      "integrity": "sha1-OwqqY8AYpTWDNzwcs6XZbMXoMBc=",
+      "version": "23.5.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-23.5.0.tgz",
+      "integrity": "sha512-iFLvYTXOn+C/s7eV+pr4E8DD7lYa2/klXMEz+lvH14qSDWAJ7S+kFmMe1SIWesATHQxopHTxRcB2nrpExhzaBA==",
       "dev": true,
       "requires": {
         "ansi-regex": "^3.0.0",
@@ -15726,6 +14286,11 @@
       "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
       "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
     },
+    "psl": {
+      "version": "1.1.29",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.1.29.tgz",
+      "integrity": "sha512-AeUmQ0oLN02flVHXWh9sSJF7mcdFq0ppid/JkErufc3hGIV/AMa8Fo9VgDo/cT2jFdOWoFvHp90qqBH54W+gjQ=="
+    },
     "public-encrypt": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.2.tgz",
@@ -15813,9 +14378,9 @@
       }
     },
     "randomatic": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-3.0.0.tgz",
-      "integrity": "sha512-VdxFOIEY3mNO5PtSRkkle/hPJDHvQhK21oa73K4yAc9qmp6N429gAyF1gZMOTMeS0/AYzaV/2Trcef+NaIonSA==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-3.1.0.tgz",
+      "integrity": "sha512-KnGPVE0lo2WoXxIZ7cPR8YBpiol4gsSuOwDSg410oHh80ZMp5EiypNqL2K4Z77vJn6lB5rap7IkAmcUlalcnBQ==",
       "requires": {
         "is-number": "^4.0.0",
         "kind-of": "^6.0.0",
@@ -16633,30 +15198,37 @@
       }
     },
     "request": {
-      "version": "2.87.0",
-      "resolved": "https://registry.npmjs.org/request/-/request-2.87.0.tgz",
-      "integrity": "sha512-fcogkm7Az5bsS6Sl0sibkbhcKsnyon/jV1kF3ajGmF0c8HrttdKTPRT9hieOaQHA5HEq6r8OyWOo/o781C1tNw==",
+      "version": "2.88.0",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
+      "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
       "requires": {
         "aws-sign2": "~0.7.0",
-        "aws4": "^1.6.0",
+        "aws4": "^1.8.0",
         "caseless": "~0.12.0",
-        "combined-stream": "~1.0.5",
-        "extend": "~3.0.1",
+        "combined-stream": "~1.0.6",
+        "extend": "~3.0.2",
         "forever-agent": "~0.6.1",
-        "form-data": "~2.3.1",
-        "har-validator": "~5.0.3",
+        "form-data": "~2.3.2",
+        "har-validator": "~5.1.0",
         "http-signature": "~1.2.0",
         "is-typedarray": "~1.0.0",
         "isstream": "~0.1.2",
         "json-stringify-safe": "~5.0.1",
-        "mime-types": "~2.1.17",
-        "oauth-sign": "~0.8.2",
+        "mime-types": "~2.1.19",
+        "oauth-sign": "~0.9.0",
         "performance-now": "^2.1.0",
-        "qs": "~6.5.1",
-        "safe-buffer": "^5.1.1",
-        "tough-cookie": "~2.3.3",
+        "qs": "~6.5.2",
+        "safe-buffer": "^5.1.2",
+        "tough-cookie": "~2.4.3",
         "tunnel-agent": "^0.6.0",
-        "uuid": "^3.1.0"
+        "uuid": "^3.3.2"
+      },
+      "dependencies": {
+        "qs": {
+          "version": "6.5.2",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+          "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
+        }
       }
     },
     "request-promise-core": {
@@ -16744,11 +15316,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz",
       "integrity": "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY="
-    },
-    "resolve-pathname": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/resolve-pathname/-/resolve-pathname-2.2.0.tgz",
-      "integrity": "sha512-bAFz9ld18RzJfddgrO2e/0S2O81710++chRMUxHjXOYKF6jTAMrUNZrEZ1PvV0zlhfjidm08iRPdTLPno1FuRg=="
     },
     "resolve-url": {
       "version": "0.2.1",
@@ -17033,44 +15600,6 @@
       "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-1.5.0.tgz",
       "integrity": "sha512-Ga8c8NjAAp46Br4+0oZ2WxJCwIzwP60Gq1YPgU+39PiTVxyed/iKE/zyZI6+UlVYH5Q4PaQdHhcegIFPZTUfoQ=="
     },
-    "serve": {
-      "version": "9.4.0",
-      "resolved": "https://registry.npmjs.org/serve/-/serve-9.4.0.tgz",
-      "integrity": "sha512-a5TpnFytY2r59g0M3L9g2HvlLBcTHeevR8gTnDkzMWECfV2c8tUCEGC9tl3YYWM7xucdkUmov+xyKjWamQQJ7Q==",
-      "requires": {
-        "@zeit/schemas": "1.7.0",
-        "ajv": "6.5.2",
-        "arg": "2.0.0",
-        "boxen": "1.3.0",
-        "chalk": "2.4.1",
-        "clipboardy": "1.2.3",
-        "serve-handler": "3.6.0",
-        "update-check": "1.5.2"
-      },
-      "dependencies": {
-        "ajv": {
-          "version": "6.5.2",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.5.2.tgz",
-          "integrity": "sha512-hOs7GfvI6tUI1LfZddH82ky6mOMyTuY0mk7kE2pWpmhhUSkumzaTO5vbVwij39MdwPQWCV4Zv57Eo06NtL/GVA==",
-          "requires": {
-            "fast-deep-equal": "^2.0.1",
-            "fast-json-stable-stringify": "^2.0.0",
-            "json-schema-traverse": "^0.4.1",
-            "uri-js": "^4.2.1"
-          }
-        },
-        "fast-deep-equal": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
-          "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
-        },
-        "json-schema-traverse": {
-          "version": "0.4.1",
-          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-          "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
-        }
-      }
-    },
     "serve-favicon": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/serve-favicon/-/serve-favicon-2.5.0.tgz",
@@ -17095,41 +15624,6 @@
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
           "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
           "dev": true
-        }
-      }
-    },
-    "serve-handler": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/serve-handler/-/serve-handler-3.6.0.tgz",
-      "integrity": "sha512-YPMV1OCfOxub4OnGQQtcGEJNI6e49r0vfSid2U5xrcOB1l6TFWfvHmUhEbfrvU7sqhZgmicfVtVBiAAGRH7NTA==",
-      "requires": {
-        "bytes": "3.0.0",
-        "content-disposition": "0.5.2",
-        "fast-url-parser": "1.1.3",
-        "glob-slasher": "1.0.1",
-        "mime-types": "2.1.18",
-        "minimatch": "3.0.4",
-        "path-is-inside": "1.0.2",
-        "path-to-regexp": "2.2.1"
-      },
-      "dependencies": {
-        "mime-db": {
-          "version": "1.33.0",
-          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.33.0.tgz",
-          "integrity": "sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ=="
-        },
-        "mime-types": {
-          "version": "2.1.18",
-          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
-          "integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
-          "requires": {
-            "mime-db": "~1.33.0"
-          }
-        },
-        "path-to-regexp": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-2.2.1.tgz",
-          "integrity": "sha512-gu9bD6Ta5bwGrrU8muHzVOBFFREpp2iRkVfhBJahwJ6p6Xw20SjT0MxLnwkjOibQmGSYhiUnf2FLe7k+jcFmGQ=="
         }
       }
     },
@@ -17720,14 +16214,6 @@
       "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=",
       "dev": true
     },
-    "steno": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/steno/-/steno-0.4.4.tgz",
-      "integrity": "sha1-BxEFvfwobmYVwEA8J+nXtdy4Vcs=",
-      "requires": {
-        "graceful-fs": "^4.1.3"
-      }
-    },
     "stream-browserify": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.1.tgz",
@@ -17916,13 +16402,31 @@
       },
       "dependencies": {
         "browserslist": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.0.1.tgz",
-          "integrity": "sha512-QqiiIWchEIkney3wY53/huI7ZErouNAdvOkjorUALAwRcu3tEwOV3Sh6He0DnP38mz1JjBpCBb50jQBmaYuHPw==",
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.0.2.tgz",
+          "integrity": "sha512-lpujC4zv1trcKUUwfD4pFVNga4YSpB3sLB+/I+A8gvGQxno1c0dMB2aCQy0FE5oUNIDjD9puFiFF0zeS6Ji48w==",
           "requires": {
-            "caniuse-lite": "^1.0.30000865",
-            "electron-to-chromium": "^1.3.52",
-            "node-releases": "^1.0.0-alpha.10"
+            "caniuse-lite": "^1.0.30000876",
+            "electron-to-chromium": "^1.3.57",
+            "node-releases": "^1.0.0-alpha.11"
+          }
+        },
+        "caniuse-lite": {
+          "version": "1.0.30000878",
+          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000878.tgz",
+          "integrity": "sha512-/dCGTdLCnjVJno1mFRn7Y6eit3AYaeFzSrMQHCoK0LEQaWl5snuLex1Ky4b8/Qu2ig5NgTX4cJx65hH9546puA=="
+        },
+        "electron-to-chromium": {
+          "version": "1.3.59",
+          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.59.tgz",
+          "integrity": "sha512-PbJGGpDSNn3fyUN1eQESAmnMT+a1QAO4NEZgikDuGOn7tbAuMHF87jNna+NoVsMBfEEYzfpn/ay88HgDCJUbQA=="
+        },
+        "node-releases": {
+          "version": "1.0.0-alpha.11",
+          "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.0.0-alpha.11.tgz",
+          "integrity": "sha512-CaViu+2FqTNYOYNihXa5uPS/zry92I3vPU4nCB6JB3OeZ2UGtOpF5gRwuN4+m3hbEcL47bOXyun1jX2iC+3uEQ==",
+          "requires": {
+            "semver": "^5.3.0"
           }
         },
         "postcss-selector-parser": {
@@ -17988,6 +16492,22 @@
         "util.promisify": "~1.0.0"
       },
       "dependencies": {
+        "colors": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
+          "integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM="
+        },
+        "css-select": {
+          "version": "1.3.0-rc0",
+          "resolved": "https://registry.npmjs.org/css-select/-/css-select-1.3.0-rc0.tgz",
+          "integrity": "sha1-b5MZaqrnN2ZuoQNqjLFKj8t6kjE=",
+          "requires": {
+            "boolbase": "^1.0.0",
+            "css-what": "2.1",
+            "domutils": "1.5.1",
+            "nth-check": "^1.0.1"
+          }
+        },
         "js-yaml": {
           "version": "3.10.0",
           "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.10.0.tgz",
@@ -18303,10 +16823,11 @@
       }
     },
     "tough-cookie": {
-      "version": "2.3.4",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
-      "integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
+      "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
       "requires": {
+        "psl": "^1.1.24",
         "punycode": "^1.4.1"
       },
       "dependencies": {
@@ -18317,14 +16838,6 @@
         }
       }
     },
-    "toxic": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/toxic/-/toxic-1.0.1.tgz",
-      "integrity": "sha512-WI3rIGdcaKULYg7KVoB0zcjikqvcYYvcuT6D89bFPz2rVR0Rl0PK6x8/X62rtdLtBKIE985NzVf/auTtGegIIg==",
-      "requires": {
-        "lodash": "^4.17.10"
-      }
-    },
     "tr46": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
@@ -18333,11 +16846,6 @@
       "requires": {
         "punycode": "^2.1.0"
       }
-    },
-    "treeify": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/treeify/-/treeify-1.1.0.tgz",
-      "integrity": "sha512-1m4RA7xVAJrSGrrXGs0L3YTwyvBs2S8PbRHaLZAkFw7JR8oIFwYtysxlBZhYIa7xSyiYJKZ3iGrrk55cGA3i9A=="
     },
     "trim-newlines": {
       "version": "1.0.0",
@@ -18643,15 +17151,6 @@
       "resolved": "https://registry.npmjs.org/upath/-/upath-1.1.0.tgz",
       "integrity": "sha512-bzpH/oBhoS/QI/YtbkqCg6VEiPYjSZtrHQM6/QnJS6OL9pKUFLqb3aFh4Scvwm45+7iAgiMkLhSbaZxUqmrprw=="
     },
-    "update-check": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/update-check/-/update-check-1.5.2.tgz",
-      "integrity": "sha512-1TrmYLuLj/5ZovwUS7fFd1jMH3NnFDN1y1A8dboedIDt7zs/zJMo6TwwlhYKkSeEwzleeiSBV5/3c9ufAQWDaQ==",
-      "requires": {
-        "registry-auth-token": "3.3.2",
-        "registry-url": "3.1.0"
-      }
-    },
     "update-notifier": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-2.5.0.tgz",
@@ -18791,11 +17290,6 @@
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
       }
-    },
-    "value-equal": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/value-equal/-/value-equal-0.4.0.tgz",
-      "integrity": "sha512-x+cYdNnaA3CxvMaTX0INdTCN8m8aF2uY9BvEqmxuYp8bL09cs/kWVQPVGcA35fMktdOsP69IgU7wFj/61dJHEw=="
     },
     "vary": {
       "version": "1.1.2",
@@ -19095,14 +17589,6 @@
         "uuid": "^3.1.0"
       }
     },
-    "webpack-md5-hash": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/webpack-md5-hash/-/webpack-md5-hash-0.0.6.tgz",
-      "integrity": "sha512-HrQ0AJpeXHRa3IjsgyyEfTx8EqYs5y/4x/WklSYsNDcqBixHzCkrmJV5U+4ks+sx7ycKoIdqWLdyuk913FCS+Q==",
-      "requires": {
-        "md5": "^2.0.0"
-      }
-    },
     "webpack-merge": {
       "version": "4.1.4",
       "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-4.1.4.tgz",
@@ -19147,12 +17633,23 @@
       "integrity": "sha512-nqHUnMXmBzT0w570r2JpJxfiSD1IzoI+HGVdd3aZ0yNi3ngvQ4jv1dtHt5VGxfI2yj5yqImPhOK4vmIh2xMbGg=="
     },
     "whatwg-encoding": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-1.0.3.tgz",
-      "integrity": "sha512-jLBwwKUhi8WtBfsMQlL4bUUcT8sMkAtQinscJAe/M4KHCkHuUJAF6vuB0tueNIw4c8ziO6AkRmgY+jL3a0iiPw==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-1.0.4.tgz",
+      "integrity": "sha512-vM9KWN6MP2mIHZ86ytcyIv7e8Cj3KTfO2nd2c8PFDqcI4bxFmQp83ibq4wadq7rL9l9sZV6o9B0LTt8ygGAAXg==",
       "dev": true,
       "requires": {
-        "iconv-lite": "0.4.19"
+        "iconv-lite": "0.4.23"
+      },
+      "dependencies": {
+        "iconv-lite": {
+          "version": "0.4.23",
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz",
+          "integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
+          "dev": true,
+          "requires": {
+            "safer-buffer": ">= 2.1.2 < 3"
+          }
+        }
       }
     },
     "whatwg-fetch": {

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "version": "1.0.0",
   "author": "Mathspy <mathspy257@gmail.com>",
   "dependencies": {
-    "gatsby": "^2.0.0-beta.72",
-    "gatsby-plugin-react-helmet": "next",
+    "gatsby": "^2.0.0-rc.0",
+    "gatsby-plugin-react-helmet": "^3.0.0-rc.0",
     "react": "^16.4.2",
     "react-dom": "^16.4.2",
     "react-helmet": "^5.2.0"
@@ -27,11 +27,11 @@
     "build-storybook": "build-storybook"
   },
   "devDependencies": {
-    "@babel/core": "^7.0.0-beta.56",
-    "@babel/plugin-proposal-class-properties": "^7.0.0-beta.56",
-    "@babel/preset-env": "^7.0.0-beta.56",
-    "@babel/preset-react": "^7.0.0-beta.56",
-    "@babel/runtime": "^7.0.0-beta.56",
+    "@babel/core": "^7.0.0-rc.2",
+    "@babel/plugin-proposal-class-properties": "^7.0.0-rc.2",
+    "@babel/preset-env": "^7.0.0-rc.2",
+    "@babel/preset-react": "^7.0.0-rc.2",
+    "@babel/runtime": "^7.0.0-rc.2",
     "@storybook/addon-actions": "^4.0.0-alpha.16",
     "@storybook/addon-links": "^4.0.0-alpha.16",
     "@storybook/addons": "^4.0.0-alpha.16",
@@ -39,12 +39,12 @@
     "babel-core": "^7.0.0-bridge.0",
     "babel-jest": "^23.4.2",
     "babel-runtime": "^6.26.0",
-    "enzyme": "^3.3.0",
-    "enzyme-adapter-react-16": "^1.1.1",
+    "enzyme": "^3.4.4",
+    "enzyme-adapter-react-16": "^1.2.0",
     "enzyme-to-json": "^3.3.4",
     "identity-obj-proxy": "^3.0.0",
-    "jest": "^23.4.2",
-    "prettier": "^1.14.0"
+    "jest": "^23.5.0",
+    "prettier": "^1.14.2"
   },
   "repository": {
     "type": "git",
@@ -77,7 +77,6 @@
     ],
     "snapshotSerializers": [
       "enzyme-to-json/serializer"
-    ],
-    "testURL": "http://localhost"
+    ]
   }
 }


### PR DESCRIPTION
- GatsbyRC now uses __PATH_PREFIX__ in development, mocked it for Storybook
- GatsbyRC renamed ___push to ___navigate, renamed accordingly
- GatsbyRC uses @Reach/Router which no longer needs Link mocking
- Jest no longer needs testURL

Fixes #7